### PR TITLE
境界線をクリックしたとき、ウィンドウがフォアグラウンド化されない問題の修正

### DIFF
--- a/VS2012LikeWindow2/Views/Chrome/GlowWindow.cs
+++ b/VS2012LikeWindow2/Views/Chrome/GlowWindow.cs
@@ -140,6 +140,11 @@ namespace VS2012LikeWindow2.Views.Chrome
 
 			if (msg == (int)WM.LBUTTONDOWN)
 			{
+				if (!this.owner.IsActive)
+				{
+					this.owner.Activate();
+				}
+
 				var ptScreen = lParam.ToPoint();
 
 				NativeMethods.PostMessage(


### PR DESCRIPTION
一部挙動に問題があったので修正しました。具体的には:
- 非アクティブの状態で境界線をクリックした際、ウィンドウがフォアグラウンド化されない (アクティブ化はされる) こと。
- またその際、フォアグラウンド化すると、GlowWindow が MetroWindow の真下にならないこと。
