### PR TITLE
GlowWindowの発光が既定DPIでのみ処理されていたのを修正

### DIFF
--- a/MetroRadiance.Chrome/Internal/GlowWindow.cs
+++ b/MetroRadiance.Chrome/Internal/GlowWindow.cs
@@ -156,6 +156,8 @@ namespace MetroRadiance.Chrome.Internal
 				this.handle.SetClassLong(ClassLongFlags.GclStyle, cs);
 
 				source.AddHook(this.WndProc);
+
+				systemDpi = this.GetSystemDpi();
 			}
 		}
 
@@ -249,6 +251,11 @@ namespace MetroRadiance.Chrome.Internal
 				{
 					NativeMethods.SendMessage(this.ownerHandle, WM.NCLBUTTONDBLCLK, (IntPtr)HitTestValues.HTBOTTOM, IntPtr.Zero);
 				}
+			}
+
+			if (msg == (int)WM.DPICHANGED)
+			{
+				systemDpi = this.GetSystemDpi();
 			}
 
 			return IntPtr.Zero;


### PR DESCRIPTION
DPI = 144で動作させたときに発光位置がずれてました。
![glow](https://f.cloud.github.com/assets/2058878/2041126/8abbd69e-89c1-11e3-9be8-05ffa5f38b61.png)

OnSourceInitializedとWM.DPICHANGEDの2か所で、保持しているDPIを更新するようにしました。
