### PR TITLE
When click CaptionIcon, fix system menu position in high/per-monitor dpi environment.

### DIFF
--- a/MetroRadiance/Controls/CaptionIcon.cs
+++ b/MetroRadiance/Controls/CaptionIcon.cs
@@ -58,7 +58,7 @@ namespace MetroRadiance.Controls
 
 		protected override void OnMouseDown(MouseButtonEventArgs e)
 		{
-			var window = Window.GetWindow(this);
+			var window = Window.GetWindow(this) as MetroWindow;
 			if (window == null)
 			{
 				base.OnMouseDown(e);
@@ -73,7 +73,7 @@ namespace MetroRadiance.Controls
 					{
 						this.isSystemMenuOpened = true;
 						var point = this.PointToScreen(new Point(0, this.ActualHeight));
-						SystemCommands.ShowSystemMenu(window, point);
+						SystemCommands.ShowSystemMenu(window, new Point(point.X / window.currentDpi.ScaleX, point.Y / window.currentDpi.ScaleY));
 					}
 					else
 					{

--- a/MetroRadiance/Controls/MetroWindow.cs
+++ b/MetroRadiance/Controls/MetroWindow.cs
@@ -38,7 +38,7 @@ namespace MetroRadiance.Controls
 		/// <summary>
 		/// このウィンドウが表示されているモニターの現在の DPI。
 		/// </summary>
-		private Dpi currentDpi;
+		internal Dpi currentDpi;
 
 		private HwndSource source;
 		private FrameworkElement resizeGrip;
@@ -175,13 +175,16 @@ namespace MetroRadiance.Controls
 			this.source = PresentationSource.FromVisual(this) as HwndSource;
 			if (this.source == null) return;
 
+			this.systemDpi = this.GetSystemDpi() ?? Dpi.Default;
 			if (PerMonitorDpi.IsSupported)
 			{
-				this.systemDpi = this.GetSystemDpi() ?? Dpi.Default;
-
 				this.currentDpi = this.source.GetDpi();
 				this.ChangeDpi(this.currentDpi);
 				this.source.AddHook(this.WndProc);
+			}
+			else
+			{
+				this.currentDpi = this.systemDpi;
 			}
 
 			if (this.WindowSettings == null)


### PR DESCRIPTION
High/Per-monitor DPI 環境にて、CaptionIcon をクリックしたときに表示されるシステム メニューの表示がずれる問題を修正しました。
- Windows 7 (High DPI)
- Windows 8.1 Update (Per-monitor DPI)

にて動作確認済みです。
