### PR TITLE
ResizeModeがNoResizeの時の挙動を修正

### DIFF
--- a/MetroRadiance.Chrome/Internal/GlowWindow.cs
+++ b/MetroRadiance.Chrome/Internal/GlowWindow.cs
@@ -261,6 +261,11 @@ namespace MetroRadiance.Chrome.Internal
 			}
 			if (msg == (int)WM.NCHITTEST)
 			{
+				if (this.owner.ResizeMode == ResizeMode.NoResize)
+				{
+					return IntPtr.Zero;
+				}
+
 				var ptScreen = lParam.ToPoint();
 				var ptClient = this.PointFromScreen(ptScreen);
 


### PR DESCRIPTION
GrowWindowのオーナーWindowのResizeModeプロパティがNoResizeになっているとき、
本来表示されないはずのリサイズカーソルが表示されるバグを修正。
