### PR TITLE
Popup position bug fix when CaptionIcon is right-clicked in high dpi environment.

### DIFF
--- a/MetroRadiance/Controls/CaptionIcon.cs
+++ b/MetroRadiance/Controls/CaptionIcon.cs
@@ -89,13 +89,15 @@ namespace MetroRadiance.Controls
 
 		protected override void OnMouseRightButtonUp(MouseButtonEventArgs e)
 		{
-			base.OnMouseRightButtonUp(e);
-
-			var window = Window.GetWindow(this);
-			if (window == null) return;
+			var window = Window.GetWindow(this) as MetroWindow;
+			if (window == null)
+			{
+				base.OnMouseRightButtonUp(e);
+				return;
+			}
 
 			var point = this.PointToScreen(e.GetPosition(this));
-			SystemCommands.ShowSystemMenu(window, point);
+			SystemCommands.ShowSystemMenu(window, new Point(point.X / window.currentDpi.ScaleX, point.Y / window.currentDpi.ScaleY));
 		}
 
 		protected override void OnMouseLeave(MouseEventArgs e)


### PR DESCRIPTION
Japanese: High DPI 環境で CaptionIcon を右クリックしたとき、ポップアップ位置がおかしい問題の修正