### PR TITLE
Modified handling of WM_DPICHANGED

### DIFF
--- a/MetroRadiance/Controls/MetroWindow.cs
+++ b/MetroRadiance/Controls/MetroWindow.cs
@@ -281,8 +281,8 @@ namespace MetroRadiance.Controls
 			}
 			else if (msg == (int)WM.DPICHANGED)
 			{
-				var dpiX = wParam.ToHiWord();
-				var dpiY = wParam.ToLoWord();
+				var dpiX = wParam.ToLoWord();
+				var dpiY = wParam.ToHiWord();
 				this.ChangeDpi(new Dpi(dpiX, dpiY));
 				handled = true;
 			}


### PR DESCRIPTION
According to MSDN ([WM_DPICHANGED](http://msdn.microsoft.com/en-us/library/windows/desktop/dn312083.aspx)), LOWORD of wParam contains the X-axis value and HIWORD of wParam contains Y-axis value.
