### PR TITLE
Fix exception in method MetroWindow.OnClosing.

### DIFF
--- a/MetroRadiance/Controls/MetroWindow.cs
+++ b/MetroRadiance/Controls/MetroWindow.cs
@@ -238,7 +238,7 @@ namespace MetroRadiance.Controls
 		{
 			base.OnClosing(e);
 
-			if (!e.Cancel)
+			if (!e.Cancel && this.WindowSettings != null)
 			{
 				WINDOWPLACEMENT placement;
 				var hwnd = new WindowInteropHelper(this).Handle;


### PR DESCRIPTION
WindowSettings が初期化される前にウィンドウが閉じられる場合、例外が発生する問題を修正しました。