### PR TITLE
SystemUsesLightTheme に対応した設定を取得するプロパティを追加

### DIFF
--- a/source/MetroRadiance.Core/Platform/WindowsTheme.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsTheme.cs
@@ -11,9 +11,14 @@ namespace MetroRadiance.Platform
 	public static class WindowsTheme
 	{
 		/// <summary>
-		/// Windows のテーマ設定と、その変更通知機能へアクセスできるようにします。
+		/// Windows の既定のアプリテーマ設定と、その変更通知機能へアクセスできるようにします。
 		/// </summary>
 		public static ThemeValue Theme { get; } = new ThemeValue();
+
+		/// <summary>
+		/// Windows の既定のシステムテーマ設定と、その変更通知機能へアクセスできるようにします。
+		/// </summary>
+		public static SystemThemeValue SystemTheme { get; } = new SystemThemeValue();
 
 		/// <summary>
 		/// Windows のアクセント カラー設定と、その変更通知機能へアクセスできるようにします。

--- a/source/MetroRadiance.Core/Platform/WindowsThemeValues.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsThemeValues.cs
@@ -41,6 +41,17 @@ namespace MetroRadiance.Platform
 		}
 	}
 
+	public class SystemThemeValue : ThemeValue
+	{
+		internal override Theme GetValue()
+		{
+			const string keyName = @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
+			const string valueName = "SystemUsesLightTheme";
+
+			return (Registry.GetValue(keyName, valueName, null) as int? ?? (int)base.GetValue()) == 0 ? Theme.Dark : Theme.Light;
+		}
+	}
+
 	public class AccentValue : WindowsThemeValue<Color>
 	{
 		internal override Color GetValue()


### PR DESCRIPTION
Windows 10 (1903)で追加されたタスクバーの色を取得する `SystemThemeValue` を追加しました。