### PR TITLE
Added a theme change and an AcrylicBlurWindow with an acrylic effect background.

### DIFF
--- a/samples/MetroRadiance.Showcase/MetroRadiance.Showcase.csproj
+++ b/samples/MetroRadiance.Showcase/MetroRadiance.Showcase.csproj
@@ -91,6 +91,9 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="UI\AcrylicBlurWindowSample.xaml.cs">
+      <DependentUpon>AcrylicBlurWindowSample.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UI\BlurWindowSample.xaml.cs">
       <DependentUpon>BlurWindowSample.xaml</DependentUpon>
     </Compile>
@@ -100,6 +103,10 @@
     <Compile Include="UI\ThemeSamples.xaml.cs">
       <DependentUpon>ThemeSamples.xaml</DependentUpon>
     </Compile>
+    <Page Include="UI\AcrylicBlurWindowSample.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="UI\BlurWindowSample.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/samples/MetroRadiance.Showcase/UI/AcrylicBlurWindowSample.xaml
+++ b/samples/MetroRadiance.Showcase/UI/AcrylicBlurWindowSample.xaml
@@ -1,0 +1,109 @@
+﻿<metro:AcrylicBlurWindow x:Class="MetroRadiance.Showcase.UI.AcrylicBlurWindowSample"
+						 x:Name="AcrylicBlurWindow"
+						 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+						 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+						 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+						 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+						 xmlns:metro="http://schemes.grabacr.net/winfx/2014/controls"
+						 xmlns:system="clr-namespace:System;assembly=mscorlib"
+						 mc:Ignorable="d"
+						 Title="AcrylicBlurWindow"
+						 Width="300"
+						 Height="300">
+	<Window.Resources>
+		<ObjectDataProvider x:Key="themeModeProvider"
+							MethodName="GetValues"
+							ObjectType="{x:Type system:Enum}">
+			<ObjectDataProvider.MethodParameters>
+				<x:Type TypeName="metro:BlurWindowThemeMode"/>
+			</ObjectDataProvider.MethodParameters>
+		</ObjectDataProvider>
+	</Window.Resources>
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<Border Grid.Row="0">
+			<Grid>
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="Auto" />
+				</Grid.ColumnDefinitions>
+				<Grid.RowDefinitions>
+					<RowDefinition />
+					<RowDefinition Height="8" />
+				</Grid.RowDefinitions>
+				<metro:CaptionIcon Grid.Column="0">
+					<Ellipse Width="18"
+							 Height="18"
+							 Fill="{Binding ElementName=AcrylicBlurWindow, Path=Foreground}" />
+				</metro:CaptionIcon>
+				<TextBlock Grid.Column="1"
+						   Grid.Row="0"
+						   Text="{Binding ElementName=AcrylicBlurWindow, Path=Title}"
+						   TextTrimming="CharacterEllipsis"
+						   Foreground="{Binding ElementName=AcrylicBlurWindow, Path=Foreground}"
+						   FontFamily="Segoe UI Light"
+						   FontSize="18"
+						   Margin="3,0,0,0"
+						   VerticalAlignment="Center" />
+				<metro:SystemButtons Grid.Column="2"
+									 Grid.Row="0"
+									 VerticalAlignment="Top" />
+			</Grid>
+		</Border>
+
+		<StackPanel Grid.Row="1"
+					Margin="8,0,8,8">
+			<ComboBox Margin="5"
+					  ItemsSource="{Binding Source={StaticResource themeModeProvider}}"
+					  SelectedItem="{Binding ElementName=AcrylicBlurWindow, Path=ThemeMode, Mode=TwoWay}" />
+
+			<DockPanel Grid.Row="1"
+					   Margin="4">
+				<TextBlock DockPanel.Dock="Right"
+						   Text="{Binding ElementName=blurOpacitySlider, Path=Value}"
+						   Foreground="{Binding ElementName=AcrylicBlurWindow, Path=Foreground}"
+						   Margin="8,0"
+						   Width="25" />
+				<Slider x:Name="blurOpacitySlider"
+						x:FieldModifier="private"
+						Minimum="0"
+						Maximum="1"
+						Value="0.8"
+						IsSnapToTickEnabled="True"
+						TickFrequency="0.1" />
+			</DockPanel>
+
+			<CheckBox x:Name="leftBorderCheckBox"
+					  x:FieldModifier="private"
+					  Content="Left border"
+					  Foreground="{Binding ElementName=AcrylicBlurWindow, Path=Foreground}"
+					  IsChecked="True"
+					  Margin="4" />
+			<CheckBox x:Name="topBorderCheckBox"
+					  x:FieldModifier="private"
+					  Content="Top border"
+					  Foreground="{Binding ElementName=AcrylicBlurWindow, Path=Foreground}"
+					  IsChecked="True"
+					  Margin="4" />
+			<CheckBox x:Name="rightBorderCheckBox"
+					  x:FieldModifier="private"
+					  Content="Right border"
+					  Foreground="{Binding ElementName=AcrylicBlurWindow, Path=Foreground}"
+					  IsChecked="True"
+					  Margin="4" />
+			<CheckBox x:Name="bottomBorderCheckBox"
+					  x:FieldModifier="private"
+					  Content="Bottom border"
+					  Foreground="{Binding ElementName=AcrylicBlurWindow, Path=Foreground}"
+					  IsChecked="True"
+					  Margin="4" />
+		</StackPanel>
+
+	</Grid>
+</metro:AcrylicBlurWindow>

--- a/samples/MetroRadiance.Showcase/UI/AcrylicBlurWindowSample.xaml.cs
+++ b/samples/MetroRadiance.Showcase/UI/AcrylicBlurWindowSample.xaml.cs
@@ -1,0 +1,31 @@
+﻿using MetroRadiance.Interop.Win32;
+using System;
+using System.Linq;
+using System.Windows.Input;
+
+namespace MetroRadiance.Showcase.UI
+{
+	public partial class AcrylicBlurWindowSample
+	{
+		public AcrylicBlurWindowSample()
+		{
+			this.InitializeComponent();
+
+			this.blurOpacitySlider.ValueChanged += (sender, e) => this.BlurOpacity = e.NewValue;
+			this.leftBorderCheckBox.Checked += (sender, e) => this.BordersFlag |= AccentFlags.DrawLeftBorder;
+			this.leftBorderCheckBox.Unchecked += (sender, e) => this.BordersFlag ^= AccentFlags.DrawLeftBorder;
+			this.topBorderCheckBox.Checked += (sender, e) => this.BordersFlag |= AccentFlags.DrawTopBorder;
+			this.topBorderCheckBox.Unchecked += (sender, e) => this.BordersFlag ^= AccentFlags.DrawTopBorder;
+			this.rightBorderCheckBox.Checked += (sender, e) => this.BordersFlag |= AccentFlags.DrawRightBorder;
+			this.rightBorderCheckBox.Unchecked += (sender, e) => this.BordersFlag ^= AccentFlags.DrawRightBorder;
+			this.bottomBorderCheckBox.Checked += (sender, e) => this.BordersFlag |= AccentFlags.DrawBottomBorder;
+			this.bottomBorderCheckBox.Unchecked += (sender, e) => this.BordersFlag ^= AccentFlags.DrawBottomBorder;
+		}
+
+		protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+		{
+			base.OnMouseLeftButtonDown(e);
+			this.DragMove();
+		}
+	}
+}

--- a/samples/MetroRadiance.Showcase/UI/BlurWindowSample.xaml
+++ b/samples/MetroRadiance.Showcase/UI/BlurWindowSample.xaml
@@ -5,10 +5,21 @@
 				  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 				  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 				  xmlns:metro="http://schemes.grabacr.net/winfx/2014/controls"
+				  xmlns:system="clr-namespace:System;assembly=mscorlib"
 				  mc:Ignorable="d"
 				  Title="BlurWindow"
 				  Width="300"
 				  Height="300">
+	<Window.Resources>
+		<ObjectDataProvider x:Key="themeModeProvider"
+							MethodName="GetValues"
+							ObjectType="{x:Type system:Enum}">
+			<ObjectDataProvider.MethodParameters>
+				<x:Type TypeName="metro:BlurWindowThemeMode"/>
+			</ObjectDataProvider.MethodParameters>
+		</ObjectDataProvider>
+	</Window.Resources>
+
 	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
@@ -45,6 +56,54 @@
 									 VerticalAlignment="Top" />
 			</Grid>
 		</Border>
+
+		<StackPanel Grid.Row="1"
+					Margin="8,0,8,8">
+			<ComboBox Margin="5"
+					  ItemsSource="{Binding Source={StaticResource themeModeProvider}}"
+					  SelectedItem="{Binding ElementName=BlurWindow, Path=ThemeMode, Mode=TwoWay}" />
+
+			<DockPanel Grid.Row="1"
+					   Margin="4">
+				<TextBlock DockPanel.Dock="Right"
+						   Text="{Binding ElementName=blurOpacitySlider, Path=Value}"
+						   Foreground="{Binding ElementName=BlurWindow, Path=Foreground}"
+						   Margin="8,0"
+						   Width="25" />
+				<Slider x:Name="blurOpacitySlider"
+						x:FieldModifier="private"
+						Minimum="0"
+						Maximum="1"
+						Value="0.8"
+						IsSnapToTickEnabled="True"
+						TickFrequency="0.1" />
+			</DockPanel>
+
+			<CheckBox x:Name="leftBorderCheckBox"
+					  x:FieldModifier="private"
+					  Content="Left border"
+					  Foreground="{Binding ElementName=BlurWindow, Path=Foreground}"
+					  IsChecked="True"
+					  Margin="4" />
+			<CheckBox x:Name="topBorderCheckBox"
+					  x:FieldModifier="private"
+					  Content="Top border"
+					  Foreground="{Binding ElementName=BlurWindow, Path=Foreground}"
+					  IsChecked="True"
+					  Margin="4" />
+			<CheckBox x:Name="rightBorderCheckBox"
+					  x:FieldModifier="private"
+					  Content="Right border"
+					  Foreground="{Binding ElementName=BlurWindow, Path=Foreground}"
+					  IsChecked="True"
+					  Margin="4" />
+			<CheckBox x:Name="bottomBorderCheckBox"
+					  x:FieldModifier="private"
+					  Content="Bottom border"
+					  Foreground="{Binding ElementName=BlurWindow, Path=Foreground}"
+					  IsChecked="True"
+					  Margin="4" />
+		</StackPanel>
 
 	</Grid>
 </metro:BlurWindow>

--- a/samples/MetroRadiance.Showcase/UI/BlurWindowSample.xaml.cs
+++ b/samples/MetroRadiance.Showcase/UI/BlurWindowSample.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MetroRadiance.Interop.Win32;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
@@ -10,6 +11,16 @@ namespace MetroRadiance.Showcase.UI
 		public BlurWindowSample()
 		{
 			this.InitializeComponent();
+
+			this.blurOpacitySlider.ValueChanged += (sender, e) => this.BlurOpacity = e.NewValue;
+			this.leftBorderCheckBox.Checked += (sender, e) => this.BordersFlag |= AccentFlags.DrawLeftBorder;
+			this.leftBorderCheckBox.Unchecked += (sender, e) => this.BordersFlag ^= AccentFlags.DrawLeftBorder;
+			this.topBorderCheckBox.Checked += (sender, e) => this.BordersFlag |= AccentFlags.DrawTopBorder;
+			this.topBorderCheckBox.Unchecked += (sender, e) => this.BordersFlag ^= AccentFlags.DrawTopBorder;
+			this.rightBorderCheckBox.Checked += (sender, e) => this.BordersFlag |= AccentFlags.DrawRightBorder;
+			this.rightBorderCheckBox.Unchecked += (sender, e) => this.BordersFlag ^= AccentFlags.DrawRightBorder;
+			this.bottomBorderCheckBox.Checked += (sender, e) => this.BordersFlag |= AccentFlags.DrawBottomBorder;
+			this.bottomBorderCheckBox.Unchecked += (sender, e) => this.BordersFlag ^= AccentFlags.DrawBottomBorder;
 		}
 
 		protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)

--- a/samples/MetroRadiance.Showcase/UI/ControlSamples.xaml
+++ b/samples/MetroRadiance.Showcase/UI/ControlSamples.xaml
@@ -58,12 +58,20 @@
 							 Margin="4" />
 			</StackPanel>
 
-			<Button Content="BlurWindow"
-					Margin="4,8"
-					Width="140"
-					Height="30"
-					HorizontalAlignment="Left"
-					Click="HandleBlurWindowButtonClicked"/>
+            <StackPanel Margin="12,0">
+                <Button Content="BlurWindow"
+					    Margin="4,4"
+					    Width="140"
+					    Height="30"
+					    HorizontalAlignment="Left"
+					    Click="HandleBlurWindowButtonClicked"/>
+			    <Button Content="AcrylicBlurWindow"
+					    Margin="4,4"
+					    Width="140"
+					    Height="30"
+					    HorizontalAlignment="Left"
+					    Click="HandleAcrylicBlurWindowButtonClicked"/>
+              </StackPanel>
 		</StackPanel>
 	</ScrollViewer>
 </UserControl>

--- a/samples/MetroRadiance.Showcase/UI/ControlSamples.xaml.cs
+++ b/samples/MetroRadiance.Showcase/UI/ControlSamples.xaml.cs
@@ -17,6 +17,11 @@ namespace MetroRadiance.Showcase.UI
 		{
 			new BlurWindowSample().Show();
 		}
+
+		private void HandleAcrylicBlurWindowButtonClicked(object sender, RoutedEventArgs e)
+		{
+			new AcrylicBlurWindowSample().Show();
+		}
 	}
 
 	public class SampleValues

--- a/source/MetroRadiance.Core/Interop/Win32/DWMWINDOWATTRIBUTE.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/DWMWINDOWATTRIBUTE.cs
@@ -2,7 +2,7 @@
 
 namespace MetroRadiance.Interop.Win32
 {
-	public enum DWMWINDOWATTRIBUTE
+	public enum DWMWINDOWATTRIBUTE : uint
 	{
 		DWMWA_NCRENDERING_ENABLED = 1,      // [get] Is non-client rendering enabled/disabled
 		DWMWA_NCRENDERING_POLICY,           // [set] Non-client rendering policy

--- a/source/MetroRadiance.Core/Interop/Win32/User32.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/User32.cs
@@ -130,7 +130,14 @@ namespace MetroRadiance.Interop.Win32
 		[DllImport("user32.dll")]
 		public static extern bool CloseWindow(IntPtr hWnd);
 
-		[DllImport("user32.dll")]
-		internal static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		private static extern bool SetWindowCompositionAttribute(IntPtr hWnd, ref WindowCompositionAttributeData data);
+
+		public static void SetWindowCompositionAttribute(IntPtr hWnd, WindowCompositionAttributeData data)
+		{
+			var ret = SetWindowCompositionAttribute(hWnd, ref data);
+			if (!ret) throw new Win32Exception(Marshal.GetLastWin32Error());
+		}
 	}
 }

--- a/source/MetroRadiance.Core/Interop/Win32/WindowCompositionAttributeData.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/WindowCompositionAttributeData.cs
@@ -13,7 +13,9 @@ namespace MetroRadiance.Interop.Win32
 		ACCENT_ENABLE_GRADIENT = 1,
 		ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
 		ACCENT_ENABLE_BLURBEHIND = 3,
-		ACCENT_INVALID_STATE = 4
+		ACCENT_ENABLE_ACRYLICBLURBEHIND = 4, // RS4 (1803)
+		ACCENT_ENABLE_HOSTBACKDROP = 5, // RS5 (1809)
+		ACCENT_INVALID_STATE = 6
 	}
 
 	[Flags]
@@ -35,7 +37,7 @@ namespace MetroRadiance.Interop.Win32
 	{
 		public AccentState AccentState;
 		public AccentFlags AccentFlags;
-		public int GradientColor;
+		public uint GradientColor;
 		public int AnimationId;
 	}
 

--- a/source/MetroRadiance.Core/Interop/Win32/WindowCompositionAttributeData.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/WindowCompositionAttributeData.cs
@@ -9,8 +9,8 @@ namespace MetroRadiance.Interop.Win32
 {
 	public enum AccentState
 	{
-		ACCENT_DISABLED = 1,
-		ACCENT_ENABLE_GRADIENT = 0,
+		ACCENT_DISABLED = 0,
+		ACCENT_ENABLE_GRADIENT = 1,
 		ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
 		ACCENT_ENABLE_BLURBEHIND = 3,
 		ACCENT_INVALID_STATE = 4
@@ -31,7 +31,7 @@ namespace MetroRadiance.Interop.Win32
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
-	internal struct AccentPolicy
+	public struct AccentPolicy
 	{
 		public AccentState AccentState;
 		public AccentFlags AccentFlags;
@@ -39,7 +39,7 @@ namespace MetroRadiance.Interop.Win32
 		public int AnimationId;
 	}
 
-	public enum WindowCompositionAttribute
+	public enum WindowCompositionAttribute : uint
 	{
 		WCA_UNDEFINED = 0,
 		WCA_NCRENDERING_ENABLED = 1,

--- a/source/MetroRadiance.Core/Media/ColorHelper.cs
+++ b/source/MetroRadiance.Core/Media/ColorHelper.cs
@@ -16,6 +16,11 @@ namespace MetroRadiance.Media
 			return HsvColor.FromRgb(c);
 		}
 
+		public static uint GetColorAsUInt32(Color color)
+		{
+			return ((uint)color.A << 24) | ((uint)color.B << 16) | ((uint)color.G << 8) | color.R;
+		}
+
 		public static Color GetColorFromUInt32(uint color)
 		{
 			return Color.FromArgb((byte)(color >> 24), (byte)(color >> 16), (byte)(color >> 8), (byte)color);

--- a/source/MetroRadiance.Core/Platform/WindowComposition.cs
+++ b/source/MetroRadiance.Core/Platform/WindowComposition.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Media;
 using MetroRadiance.Interop.Win32;
+using MetroRadiance.Media;
 
 namespace MetroRadiance.Platform
 {
@@ -25,6 +27,17 @@ namespace MetroRadiance.Platform
 			{
 				AccentState = AccentState.ACCENT_ENABLE_BLURBEHIND,
 				AccentFlags = accentFlags,
+			};
+			SetAccentPolicy(window, accentPolicy);
+		}
+
+		public static void EnableAcrylicBlur(Window window, Color backgroundColor, AccentFlags accentFlags)
+		{
+			var accentPolicy = new AccentPolicy
+			{
+				AccentState = AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND,
+				AccentFlags = accentFlags,
+				GradientColor = ColorHelper.GetColorAsUInt32(backgroundColor),
 			};
 			SetAccentPolicy(window, accentPolicy);
 		}

--- a/source/MetroRadiance/MetroRadiance.csproj
+++ b/source/MetroRadiance/MetroRadiance.csproj
@@ -214,6 +214,7 @@
     </Compile>
     <Compile Include="UI\Accent.cs" />
     <Compile Include="UI\Controls\BlurWindow.cs" />
+    <Compile Include="UI\Controls\BlurWindowThemeMode.cs" />
     <Compile Include="UI\Interactivity\DirectWindowAction.cs" />
     <Compile Include="UI\Controls\Badge.cs" />
     <Compile Include="UI\Controls\BindableRichTextBox.cs" />

--- a/source/MetroRadiance/MetroRadiance.csproj
+++ b/source/MetroRadiance/MetroRadiance.csproj
@@ -213,6 +213,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="UI\Accent.cs" />
+    <Compile Include="UI\Controls\AcrylicBlurWindow.cs" />
     <Compile Include="UI\Controls\BlurWindow.cs" />
     <Compile Include="UI\Controls\BlurWindowThemeMode.cs" />
     <Compile Include="UI\Interactivity\DirectWindowAction.cs" />

--- a/source/MetroRadiance/UI/Controls/AcrylicBlurWindow.cs
+++ b/source/MetroRadiance/UI/Controls/AcrylicBlurWindow.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media;
+using MetroRadiance.Platform;
+
+namespace MetroRadiance.UI.Controls
+{
+	public class AcrylicBlurWindow : BlurWindow
+	{
+		private static bool IsAcrylicBlurEnabled { get; }
+
+		static AcrylicBlurWindow()
+		{
+			IsAcrylicBlurEnabled = Environment.OSVersion.Version.Build >= 17004;
+		}
+
+		internal protected override void HandleThemeChanged()
+		{
+			if (WindowsTheme.HighContrast.Current)
+			{
+				this.ToHighContrast();
+			}
+			else if (!WindowsTheme.Transparency.Current)
+			{
+				this.ToDefault();
+			}
+			else if (IsAcrylicBlurEnabled)
+			{
+				this.ToAcrylicBlur();
+			}
+			else
+			{
+				this.ToBlur();
+			}
+		}
+
+		private void ToAcrylicBlur()
+		{
+			Color background, foreground;
+			this.GetColors(out background, out foreground);
+
+			background.A = (byte)(background.A * this.BlurOpacity);
+			WindowComposition.EnableAcrylicBlur(this, background, this.BordersFlag);
+			this.ChangeProperties(Color.FromArgb(1, 0, 0, 0), foreground, Colors.Transparent, new Thickness());
+		}
+	}
+}

--- a/source/MetroRadiance/UI/Controls/AcrylicBlurWindow.cs
+++ b/source/MetroRadiance/UI/Controls/AcrylicBlurWindow.cs
@@ -20,6 +20,10 @@ namespace MetroRadiance.UI.Controls
 			{
 				this.ToHighContrast();
 			}
+			else if (!IsWindows10)
+			{
+				this.ToCompatibility();
+			}
 			else if (!WindowsTheme.Transparency.Current)
 			{
 				this.ToDefault();

--- a/source/MetroRadiance/UI/Controls/BlurWindow.cs
+++ b/source/MetroRadiance/UI/Controls/BlurWindow.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using System.Windows.Interop;
 using System.Windows.Media;
 using MetroRadiance.Interop;
 using MetroRadiance.Interop.Win32;
@@ -14,73 +15,285 @@ namespace MetroRadiance.UI.Controls
 		static BlurWindow()
 		{
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(BlurWindow), new FrameworkPropertyMetadata(typeof(BlurWindow)));
+			ResizeModeProperty.OverrideMetadata(typeof(BlurWindow), new FrameworkPropertyMetadata(ResizeMode.CanMinimize));
 			WindowStyleProperty.OverrideMetadata(typeof(BlurWindow), new FrameworkPropertyMetadata(WindowStyle.None));
 			AllowsTransparencyProperty.OverrideMetadata(typeof(BlurWindow), new FrameworkPropertyMetadata(true));
 		}
+
+		private HwndSource _source;
+
+		#region ThemeMode 依存関係プロパティ
+
+		public BlurWindowThemeMode ThemeMode
+		{
+			get { return (BlurWindowThemeMode)this.GetValue(ThemeModeProperty); }
+			set { this.SetValue(ThemeModeProperty, value); }
+		}
+		public static readonly DependencyProperty ThemeModeProperty =
+			DependencyProperty.Register("ThemeMode", typeof(BlurWindowThemeMode), typeof(BlurWindow), new UIPropertyMetadata(BlurWindowThemeMode.Default, ThemeModeChangedCallback));
+
+		private static void ThemeModeChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var instance = (BlurWindow)d;
+			instance.RemoveThemeCallback((BlurWindowThemeMode)e.OldValue);
+			instance.AddThemeCallback((BlurWindowThemeMode)e.NewValue);
+			instance.OnThemeModeChanged(e);
+			instance.HandleThemeChanged();
+		}
+
+		protected virtual void OnThemeModeChanged(DependencyPropertyChangedEventArgs e)
+		{
+		}
+
+		#endregion
+
+		#region BlurOpacity 依存関係プロパティ
+
+		public double BlurOpacity
+		{
+			get { return (double)this.GetValue(BlurOpacityProperty); }
+			set { this.SetValue(BlurOpacityProperty, value); }
+		}
+		public static readonly DependencyProperty BlurOpacityProperty =
+			DependencyProperty.Register("BlurOpacity", typeof(double), typeof(BlurWindow), new UIPropertyMetadata(0.8, BlurOpacityChangedCallback));
+
+		private static void BlurOpacityChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var instance = (BlurWindow)d;
+			instance.OnBlurOpacityChanged(e);
+			instance.HandleThemeChanged();
+		}
+
+		protected virtual void OnBlurOpacityChanged(DependencyPropertyChangedEventArgs e)
+		{
+		}
+
+		#endregion
+
+		#region DrawBorders 依存関係プロパティ
+
+		public AccentFlags BordersFlag
+		{
+			get { return (AccentFlags)this.GetValue(BordersFlagProperty); }
+			set { this.SetValue(BordersFlagProperty, value); }
+		}
+		public static readonly DependencyProperty BordersFlagProperty =
+			DependencyProperty.Register("BordersFlag", typeof(AccentFlags), typeof(BlurWindow), new UIPropertyMetadata(AccentFlags.DrawAllBorders, BordersFlagChangedCallback));
+
+		private static void BordersFlagChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var instance = (BlurWindow)d;
+			instance.OnBordersFlagChanged(e);
+			instance.HandleThemeChanged();
+		}
+
+		protected virtual void OnBordersFlagChanged(DependencyPropertyChangedEventArgs e)
+		{
+		}
+
+		#endregion
 
 		protected override void OnSourceInitialized(EventArgs e)
 		{
 			base.OnSourceInitialized(e);
 
-			WindowComposition.Set(this, AccentState.ACCENT_ENABLE_BLURBEHIND, AccentFlags.DrawAllBorders);
+			WindowsTheme.HighContrast.Changed += this.HandleThemeBooleanChanged;
+			WindowsTheme.Transparency.Changed += this.HandleThemeBooleanChanged;
+			AddThemeCallback(this.ThemeMode);
 
-			WindowsTheme.HighContrast.Changed += this.HandleThemeChanged;
-			WindowsTheme.Transparency.Changed += this.HandleThemeChanged;
-			WindowsTheme.ColorPrevalence.Changed += this.HandleThemeChanged;
+			this.HandleThemeChanged();
 
-			this.HandleThemeChanged(null, false);
+			this._source = PresentationSource.FromVisual(this) as HwndSource;
+			if (this._source == null) return;
+
+			var hWnd = this._source.Handle;
+			var wndStyle = User32.GetWindowLong(hWnd);
+			User32.SetWindowLong(hWnd, wndStyle & ~WindowStyles.WS_SYSMENU);
 		}
 
 		protected override void OnClosed(EventArgs e)
 		{
 			base.OnClosed(e);
 
-			WindowsTheme.HighContrast.Changed -= this.HandleThemeChanged;
-			WindowsTheme.Transparency.Changed -= this.HandleThemeChanged;
-			WindowsTheme.ColorPrevalence.Changed -= this.HandleThemeChanged;
+			WindowsTheme.HighContrast.Changed -= this.HandleThemeBooleanChanged;
+			WindowsTheme.Transparency.Changed -= this.HandleThemeBooleanChanged;
+			RemoveThemeCallback(this.ThemeMode);
 		}
 
-		private void HandleThemeChanged(object sender, bool value)
+		private void AddThemeCallback(BlurWindowThemeMode themeMode)
+		{
+			switch (themeMode)
+			{
+				case BlurWindowThemeMode.Default:
+					WindowsTheme.Theme.Changed += this.HandleThemeValueChanged;
+					break;
+					
+				case BlurWindowThemeMode.Accent:
+					WindowsTheme.Accent.Changed += this.HandleThemeColorChanged;
+					break;
+
+				case BlurWindowThemeMode.System:
+					WindowsTheme.Accent.Changed += this.HandleThemeColorChanged;
+					WindowsTheme.ColorPrevalence.Changed += this.HandleThemeBooleanChanged;
+					if (WindowsTheme.SystemTheme.IsDynamic)
+					{
+						WindowsTheme.SystemTheme.Changed += this.HandleThemeValueChanged;
+					}
+					break;
+
+				default:
+					break;
+			}
+		}
+
+		private void RemoveThemeCallback(BlurWindowThemeMode themeMode)
+		{
+			switch (themeMode)
+			{
+				case BlurWindowThemeMode.Default:
+					WindowsTheme.Theme.Changed -= this.HandleThemeValueChanged;
+					break;
+					
+				case BlurWindowThemeMode.Accent:
+					WindowsTheme.Accent.Changed -= this.HandleThemeColorChanged;
+					break;
+
+				case BlurWindowThemeMode.System:
+					WindowsTheme.Accent.Changed -= this.HandleThemeColorChanged;
+					WindowsTheme.ColorPrevalence.Changed -= this.HandleThemeBooleanChanged;
+					if (WindowsTheme.SystemTheme.IsDynamic)
+					{
+						WindowsTheme.SystemTheme.Changed -= this.HandleThemeValueChanged;
+					}
+					break;
+
+				default:
+					break;
+			}
+		}
+
+		private void HandleThemeBooleanChanged(object sender, bool value)
+			=> this.HandleThemeChanged();
+
+		private void HandleThemeColorChanged(object sender, Color value)
+			=> this.HandleThemeChanged();
+
+		private void HandleThemeValueChanged(object sender, Platform.Theme value)
+			=> this.HandleThemeChanged();
+
+		internal protected virtual void HandleThemeChanged()
 		{
 			if (WindowsTheme.HighContrast.Current)
 			{
 				this.ToHighContrast();
 			}
+			else if (!WindowsTheme.Transparency.Current)
+			{
+				this.ToDefault();
+			}
 			else
 			{
-				this.ToBlur(
-					WindowsTheme.Transparency.Current,
-					WindowsTheme.ColorPrevalence.Current);
+				this.ToBlur();
 			}
 		}
 
-		private void ToHighContrast()
+		internal protected void ToHighContrast()
 		{
+			WindowComposition.Disable(this);
 			this.ChangeProperties(
 				ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.ApplicationBackground),
 				ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemText),
 				SystemColors.WindowFrameColor,
-				new Thickness(2));
+				this.GetBordersFlagAsThickness(2));
 		}
 
-		private void ToBlur(bool transparency, bool colorPrevalence)
+		internal protected void ToDefault()
 		{
-			var background = colorPrevalence
-				? ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemAccentDark1)
-				: ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.DarkChromeMedium);
-			if (transparency) background.A = (byte)(background.A * 0.8);
+			Color background, foreground;
+			this.GetColors(out background, out foreground);
 
-			var foreground = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemTextDarkTheme);
+			WindowComposition.Disable(this);
+			this.ChangeProperties(background, foreground, SystemColors.WindowFrameColor, this.GetBordersFlagAsThickness(1));
+		}
 
+		internal protected void ToBlur()
+		{
+			Color background, foreground;
+			this.GetColors(out background, out foreground);
+
+			background.A = (byte)(background.A * this.BlurOpacity);
+			WindowComposition.EnableBlur(this, this.BordersFlag);
 			this.ChangeProperties(background, foreground, Colors.Transparent, new Thickness());
 		}
 
-		private void ChangeProperties(Color background, Color foreground, Color border, Thickness borderThickness)
+		internal protected void GetColors(out Color background, out Color foreground)
+		{
+			var colorPrevalence = WindowsTheme.ColorPrevalence.Current;
+			switch (this.ThemeMode)
+			{
+				case BlurWindowThemeMode.Light:
+					background = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.LightChromeMedium);
+					foreground = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemTextLightTheme);
+					break;
+
+				case BlurWindowThemeMode.Dark:
+					background = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.DarkChromeMedium);
+					foreground = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemTextDarkTheme);
+					break;
+
+				case BlurWindowThemeMode.Accent:
+					background = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemAccentDark1);
+					foreground = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemTextDarkTheme);
+					break;
+
+				case BlurWindowThemeMode.System:
+					if (colorPrevalence)
+					{
+						background = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemAccentDark1);
+						foreground = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemTextDarkTheme);
+					}
+					else if (WindowsTheme.SystemTheme.Current == Platform.Theme.Light)
+					{
+						background = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.LightChromeMedium);
+						foreground = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemTextLightTheme);
+					}
+					else
+					{
+						background = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.DarkChromeMedium);
+						foreground = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemTextDarkTheme);
+					}
+					break;
+
+				default:
+					if (WindowsTheme.Theme.Current == Platform.Theme.Dark)
+					{
+						background = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.DarkChromeMedium);
+						foreground = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemTextDarkTheme);
+					}
+					else
+					{
+						background = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.LightChromeMedium);
+						foreground = ImmersiveColor.GetColorByTypeName(ImmersiveColorNames.SystemTextLightTheme);
+					}
+					break;
+			}
+		}
+
+		internal protected void ChangeProperties(Color background, Color foreground, Color border, Thickness borderThickness)
 		{
 			this.Background = new SolidColorBrush(background);
 			this.Foreground = new SolidColorBrush(foreground);
 			this.BorderBrush = new SolidColorBrush(border);
 			this.BorderThickness = borderThickness;
+		}
+
+		private Thickness GetBordersFlagAsThickness(double width)
+		{
+			return new Thickness(
+				this.BordersFlag.HasFlag(AccentFlags.DrawLeftBorder) ? width : 0.0,
+				this.BordersFlag.HasFlag(AccentFlags.DrawTopBorder) ? width : 0.0,
+				this.BordersFlag.HasFlag(AccentFlags.DrawRightBorder) ? width : 0.0,
+				this.BordersFlag.HasFlag(AccentFlags.DrawBottomBorder) ? width : 0.0);
 		}
 	}
 }

--- a/source/MetroRadiance/UI/Controls/BlurWindowThemeMode.cs
+++ b/source/MetroRadiance/UI/Controls/BlurWindowThemeMode.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+
+namespace MetroRadiance.UI.Controls
+{
+	public enum BlurWindowThemeMode
+	{
+		Default,
+
+		Light,
+
+		Dark,
+
+		Accent,
+
+		System,
+	}
+}


### PR DESCRIPTION
<img width="637" alt="スクリーンショット 2020-07-28 18 33 19" src="https://user-images.githubusercontent.com/901816/88647281-d7443c80-d100-11ea-82f1-ce675a058b81.png">

There are a lot of issues for the acrylic blur window implemented by DWM.

- The UI response to move window is too awful. (This problem has been since 19H1, when the method of an acrylic effect was changed.)
  ref. http://sourcechord.hatenablog.com/entry/2019/05/17/235928 (Japanese)
  cf. How to make an acrylic effect: https://github.com/microsoft/microsoft-ui-xaml/blob/de788345659ba319597161149843504fbe686659/dev/Materials/Acrylic/AcrylicBrush.cpp#L697-L797
- When WPF is made completely transparent, HitTest will be passed through. The workaround is to set Alpha = 1/255.
  ref. https://github.com/riverar/sample-win32-acrylicblur/blob/e59727c30b29bac4335ca7e91774427982263c97/MainWindow.xaml#L5
- ~~Once the acrylic effect is disabled, the acrylic effect cannot be re-enabled. The workaround is to enable the acrylic effect even if the effect is not needed.~~ Resolved.

---

(以下の日本語は英語と同じ内容です)

アクリル効果の背景をもつAcrylicBlurWindowの追加，および淡色・濃色の切り替え実装。

DWM実装によるアクリル素材のウィンドウには現在の最新バージョン (May 2020 Update) で以下の問題があります。

- ウィンドウ移動のレスポンスが悪い。(19H1 以降，アクリルの表現方法が変化して以降からの問題)
  ref. http://sourcechord.hatenablog.com/entry/2019/05/17/235928
  cf. アクリル効果の作り方 https://github.com/microsoft/microsoft-ui-xaml/blob/de788345659ba319597161149843504fbe686659/dev/Materials/Acrylic/AcrylicBrush.cpp#L697-L797
- WPF側を完全な透過ウィンドウにすると，HitTestがスルーされる。
  回避方法は Alpha = 1/255 に設定する。
  ref. https://github.com/riverar/sample-win32-acrylicblur/blob/e59727c30b29bac4335ca7e91774427982263c97/MainWindow.xaml#L5
- ~~一度アクリル効果を無効化すると，アクリル効果を再有効化できない。
  回避方法は透明効果を必要としないときでもアクリル効果を有効化しておくこと。~~ 解決済み