### PR TITLE
Fix a known issue with the maximized window size

### DIFF
--- a/source/MetroRadiance.Core/Interop/Appbar.cs
+++ b/source/MetroRadiance.Core/Interop/Appbar.cs
@@ -1,0 +1,24 @@
+﻿using MetroRadiance.Interop.Win32;
+
+namespace MetroRadiance.Interop
+{
+	public static class AppBar
+	{
+		// Note: This is constant in every DPI.
+		private const int _hideAppbarSpace = 2;
+
+		public static bool HasAutoHideAppBar(RECT area, AppBarEdges targetEdge)
+		{
+			var appbar = Shell32.SHAppBarGetAutoHideBarEx(targetEdge, area);
+			return User32.IsWindow(appbar);
+		}
+
+		public static void ApplyAppbarSpace(RECT monitorArea, ref RECT workArea)
+		{
+			if (HasAutoHideAppBar(monitorArea, AppBarEdges.ABE_TOP)) workArea.Top += _hideAppbarSpace;
+			if (HasAutoHideAppBar(monitorArea, AppBarEdges.ABE_LEFT)) workArea.Left += _hideAppbarSpace;
+			if (HasAutoHideAppBar(monitorArea, AppBarEdges.ABE_RIGHT)) workArea.Right -= _hideAppbarSpace;
+			if (HasAutoHideAppBar(monitorArea, AppBarEdges.ABE_BOTTOM)) workArea.Bottom -= _hideAppbarSpace;
+		}
+	}
+}

--- a/source/MetroRadiance.Core/Interop/Win32/APPBARDATA.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/APPBARDATA.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Runtime.InteropServices;
+// ReSharper disable InconsistentNaming
+
+namespace MetroRadiance.Interop.Win32
+{
+	[StructLayout(LayoutKind.Sequential)]
+	public struct APPBARDATA
+	{
+		public int cbSize;
+		public IntPtr hWnd;
+		public uint uCallbackMessage;
+		public AppBarEdges uEdge;
+		public RECT rc;
+		public IntPtr lParam;
+	}
+}

--- a/source/MetroRadiance.Core/Interop/Win32/AppBarEdges.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/AppBarEdges.cs
@@ -1,0 +1,27 @@
+﻿// ReSharper disable InconsistentNaming
+
+namespace MetroRadiance.Interop.Win32
+{
+	public enum AppBarEdges : uint
+	{
+		/// <summary>
+		/// Left edge.
+		/// </summary>
+		ABE_LEFT = 0,
+		
+		/// <summary>
+		/// Top edge.
+		/// </summary>
+		ABE_TOP = 1,
+		
+		/// <summary>
+		/// Right edge.
+		/// </summary>
+		ABE_RIGHT = 2,
+		
+		/// <summary>
+		/// Bottom edge.
+		/// </summary>
+		ABE_BOTTOM = 3
+	}
+}

--- a/source/MetroRadiance.Core/Interop/Win32/AppBarMessages.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/AppBarMessages.cs
@@ -1,0 +1,77 @@
+﻿// ReSharper disable InconsistentNaming
+
+namespace MetroRadiance.Interop.Win32
+{
+	internal enum AppBarMessages : uint
+	{
+		/// <summary>
+		/// Registers a new appbar and specifies the message identifier that the system should use to send notification messages to the appbar.
+		/// </summary>
+		ABM_NEW = 0x0,
+		
+		/// <summary>
+		/// Unregisters an appbar, removing the bar from the system's internal list.
+		/// </summary>
+		ABM_REMOVE = 0x1,
+		
+		/// <summary>
+		/// Requests a size and screen position for an appbar.
+		/// </summary>
+		ABM_QUERYPOS = 0x2,
+		
+		/// <summary>
+		/// Sets the size and screen position of an appbar.
+		/// </summary>
+		ABM_SETPOS = 0x3,
+		
+		/// <summary>
+		/// Retrieves the autohide and always-on-top states of the Windows taskbar.
+		/// </summary>
+		ABM_GETSTATE = 0x4,
+		
+		/// <summary>
+		/// Retrieves the bounding rectangle of the Windows taskbar. Note that this applies only to the system taskbar.
+		/// Other objects, particularly toolbars supplied with third-party software, also can be present.
+		/// As a result, some of the screen area not covered by the Windows taskbar might not be visible to the user.
+		/// To retrieve the area of the screen not covered by both the taskbar and other app bars—the working area available
+		/// to your application—, use the GetMonitorInfo function.
+		/// </summary>
+		ABM_GETTASKBARPOS = 0x5,
+		
+		/// <summary>
+		/// Notifies the system to activate or deactivate an appbar.
+		/// The lParam member of the APPBARDATA pointed to by pData is set to TRUE to activate or FALSE to deactivate.
+		/// </summary>
+		ABM_ACTIVATE = 0x6,
+		
+		/// <summary>
+		/// Retrieves the handle to the autohide appbar associated with a particular edge of the screen.
+		/// </summary>
+		ABM_GETAUTOHIDEBAR = 0x7,
+		
+		/// <summary>
+		/// Registers or unregisters an autohide appbar for an edge of the screen.
+		/// </summary>
+		ABM_SETAUTOHIDEBAR = 0x8,
+		
+		/// <summary>
+		/// Notifies the system when an appbar's position has changed.
+		/// </summary>
+		ABM_WINDOWPOSCHANGED = 0x9,
+		
+		/// <summary>
+		/// Sets the state of the appbar's autohide and always-on-top attributes.
+		/// </summary>
+		ABM_SETSTATE = 0xA,
+		
+		/// <summary>
+		/// Retrieves the handle to the autohide appbar associated with a particular edge of a particular monitor.
+		/// </summary>
+		ABM_GETAUTOHIDEBAREX = 0xB,
+		
+		/// <summary>
+		/// Registers or unregisters an autohide appbar for an edge of a particular monitor.
+		/// </summary>
+		ABM_SETAUTOHIDEBAREX = 0xC
+	}
+}

--- a/source/MetroRadiance.Core/Interop/Win32/AppBarStates.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/AppBarStates.cs
@@ -1,0 +1,19 @@
+﻿using System;
+// ReSharper disable InconsistentNaming
+
+namespace MetroRadiance.Interop.Win32
+{
+	[Flags]
+	public enum AppBarState : uint
+	{
+		/// <summary>
+		/// The taskbar is in the autohide state.
+		/// <summary>
+		ABS_AUTOHIDE = 0x1,
+
+		/// <summary>
+		/// he taskbar is in the always-on-top state.
+		/// <summary>
+		ABS_ALWAYSONTOP = 0x2
+	}
+}

--- a/source/MetroRadiance.Core/Interop/Win32/MONITORINFOEX.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/MONITORINFOEX.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.InteropServices;
+// ReSharper disable InconsistentNaming
+
+namespace MetroRadiance.Interop.Win32
+{
+	public enum MONITORINFOF : uint
+	{
+		MONITORINFOF_PRIMARY = 1
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct MONITORINFO
+	{
+		public uint cbSize;
+		public RECT rcMonitor;
+		public RECT rcWork;
+		public MONITORINFOF dwFlags;
+	}
+
+	[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+	public struct MONITORINFOEX
+	{
+		public uint cbSize;
+		public RECT rcMonitor;
+		public RECT rcWork;
+		public MONITORINFOF dwFlags;
+
+		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+		public string szDevice;
+	}
+}

--- a/source/MetroRadiance.Core/Interop/Win32/NCCALCSIZE_PARAMS.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/NCCALCSIZE_PARAMS.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.InteropServices;
+// ReSharper disable InconsistentNaming
+
+namespace MetroRadiance.Interop.Win32
+{
+	[StructLayout(LayoutKind.Sequential)]
+	public struct WINDOWPOS
+	{
+		public IntPtr hwnd;
+		public IntPtr hwndInsertAfter;
+		public int x;
+		public int y;
+		public int cx;
+		public int cy;
+		public SetWindowPosFlags flags;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct NCCALCSIZE_PARAMS
+	{
+		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+		public RECT[] rgrc;
+		public WINDOWPOS lppos;
+	}
+}

--- a/source/MetroRadiance.Core/Interop/Win32/SetWindowPosFlags.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/SetWindowPosFlags.cs
@@ -6,15 +6,48 @@ namespace MetroRadiance.Interop.Win32
 	[Flags]
 	public enum SetWindowPosFlags
 	{
-		SWP_NOSIZE = 0x1,
-		SWP_NOMOVE = 0x2,
-		SWP_NOZORDER = 0x4,
-		SWP_NOREDRAW = 0x8,
-		SWP_NOACTIVATE = 0x10,
-		SWP_FRAMECHANGED = 0x20,
+		/// <summary>
+		/// Retains the current size (ignores the cx and cy parameters).
+		/// </summary>
+		SWP_NOSIZE = 0x0001,
+
+		/// <summary>
+		/// Retains the current position (ignores X and Y parameters).
+		/// </summary>
+		SWP_NOMOVE = 0x0002,
+
+		/// <summary>
+		/// Retains the current Z order (ignores the hWndInsertAfter parameter).
+		/// </summary>
+		SWP_NOZORDER = 0x0004,
+
+		SWP_NOREDRAW = 0x0008,
+		SWP_NOACTIVATE = 0x0010,
+		SWP_FRAMECHANGED = 0x0020,
 		SWP_SHOWWINDOW = 0x0040,
-		SWP_NOOWNERZORDER = 0x200,
+		SWP_HIDEWINDOW = 0x0080,
+		SWP_NOCOPYBITS = 0x0100,
+		
+		/// <summary>
+		/// Does not change the owner window's position in the Z order.
+		/// </summary>
+		SWP_NOOWNERZORDER = 0x0200,
+
+		/// <summary>
+		/// Prevents the window from receiving the WM_WINDOWPOSCHANGING message.
+		/// </summary>
 		SWP_NOSENDCHANGING = 0x0400,
+		
+		/// <summary>
+		/// Prevents generation of the WM_SYNCPAINT message.
+		/// </summary>
+		SWP_DEFERERASE = 0x2000,
+		
+		/// <summary>
+		/// If the calling thread and the thread that owns the window are attached to different input queues,
+		/// the system posts the request to the thread that owns the window.
+		/// This prevents the calling thread from blocking its execution while other threads process the request.
+		/// </summary>
 		SWP_ASYNCWINDOWPOS = 0x4000,
 	}
 }

--- a/source/MetroRadiance.Core/Interop/Win32/Shell32.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/Shell32.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace MetroRadiance.Interop.Win32
+{
+	public static class Shell32
+	{
+		[DllImport("shell32")]
+		internal static extern IntPtr SHAppBarMessage(AppBarMessages dwMessage, ref APPBARDATA pData);
+
+		public static AppBarState SHAppBarGetState(ref APPBARDATA pData)
+		{
+			return (AppBarState)SHAppBarMessage(AppBarMessages.ABM_GETSTATE, ref pData);
+		}
+		
+		public static AppBarEdges SHAppBarGetTaskbarPos(RECT rc)
+		{
+			var data = new APPBARDATA()
+			{
+				cbSize = Marshal.SizeOf(typeof(APPBARDATA)),
+				rc = rc,
+			};
+			if (SHAppBarMessage(AppBarMessages.ABM_GETTASKBARPOS, ref data) == IntPtr.Zero)
+			{
+				throw new Win32Exception();
+			}
+			return data.uEdge;
+		}
+
+		public static IntPtr SHAppBarGetAutoHideBar(AppBarEdges uEdge)
+		{
+			var data = new APPBARDATA()
+			{
+				cbSize = Marshal.SizeOf(typeof(APPBARDATA)),
+				uEdge = uEdge,
+			};
+			return SHAppBarMessage(AppBarMessages.ABM_GETAUTOHIDEBAR, ref data);
+		}
+
+		public static IntPtr SHAppBarGetAutoHideBarEx(AppBarEdges uEdge, RECT rc)
+		{
+			var data = new APPBARDATA()
+			{
+				cbSize = Marshal.SizeOf(typeof(APPBARDATA)),
+				uEdge = uEdge,
+				rc = rc,
+			};
+			return SHAppBarMessage(AppBarMessages.ABM_GETAUTOHIDEBAREX, ref data);
+		}
+	}
+}

--- a/source/MetroRadiance.Core/Interop/Win32/User32.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/User32.cs
@@ -100,6 +100,10 @@ namespace MetroRadiance.Interop.Win32
 		public static extern IntPtr MonitorFromWindow(IntPtr hwnd, MonitorDefaultTo dwFlags);
 
 		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool IsWindow(IntPtr hWnd);
+
+		[DllImport("user32.dll")]
 		public static extern IntPtr GetActiveWindow();
 
 		[DllImport("user32.dll")]

--- a/source/MetroRadiance.Core/Interop/Win32/User32.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/User32.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -38,8 +39,19 @@ namespace MetroRadiance.Interop.Win32
 		[DllImport("user32.dll")]
 		public static extern bool SetWindowPlacement(IntPtr hWnd, [In] ref WINDOWPLACEMENT lpwndpl);
 
-		[DllImport("user32.dll")]
-		public static extern bool GetWindowPlacement(IntPtr hWnd, out WINDOWPLACEMENT lpwndpl);
+		[DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		private static extern bool GetWindowPlacement(IntPtr hWnd, out WINDOWPLACEMENT lpwndpl);
+
+		public static WINDOWPLACEMENT GetWindowPlacement(IntPtr hWnd)
+		{
+			WINDOWPLACEMENT wndpl;
+			if (!GetWindowPlacement(hWnd, out wndpl)) 
+			{
+				throw new Win32Exception(Marshal.GetLastWin32Error());
+			}
+			return wndpl;
+		}
 
 		[DllImport("user32.dll")]
 		public static extern bool GetClientRect(IntPtr hWnd, out RECT rect);
@@ -76,6 +88,13 @@ namespace MetroRadiance.Interop.Win32
 		[DllImport("user32.dll", EntryPoint = "SetClassLongPtr")]
 		public static extern IntPtr SetClassLong64(IntPtr hWnd, ClassLongPtrIndex nIndex, IntPtr dwNewLong);
 
+		[DllImport("user32.dll", EntryPoint = "GetMonitorInfoW", SetLastError = true, ExactSpelling = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFO lpmi);
+
+		[DllImport("user32.dll", EntryPoint = "GetMonitorInfoW", SetLastError = true, ExactSpelling = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool GetMonitorInfoEx(IntPtr hMonitor, ref MONITORINFOEX lpmi);
 
 		[DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
 		public static extern IntPtr MonitorFromWindow(IntPtr hwnd, MonitorDefaultTo dwFlags);

--- a/source/MetroRadiance.Core/Interop/Win32/WindowValidRects.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/WindowValidRects.cs
@@ -1,0 +1,63 @@
+﻿using System;
+// ReSharper disable InconsistentNaming
+
+namespace MetroRadiance.Interop.Win32
+{
+	[Flags]
+	public enum WindowValidRects : uint
+	{
+		/// <summary>
+		/// Specifies that the client area of the window is to be preserved and aligned with the top of the new position of the window.
+		/// For example, to align the client area to the upper-left corner, return the WVR_ALIGNTOP and WVR_ALIGNLEFT values.
+		/// <summary>
+		WVR_ALIGNTOP = 0x010,
+		
+		/// <summary>
+		/// Specifies that the client area of the window is to be preserved and aligned with the left side of the new position of the window.
+		/// For example, to align the client area to the lower-left corner, return the WVR_ALIGNLEFT and WVR_ALIGNBOTTOM values.
+		/// <summary>
+		WVR_ALIGNLEFT = 0x020,
+		
+		/// <summary>
+		/// Specifies that the client area of the window is to be preserved and aligned with the bottom of the new position of the window.
+		/// For example, to align the client area to the top-left corner, return the WVR_ALIGNTOP and WVR_ALIGNLEFT values.
+		/// <summary>
+		WVR_ALIGNBOTTOM = 0x040,
+		
+		/// <summary>
+		/// Specifies that the client area of the window is to be preserved and aligned with the right side of the new position of the window.
+		/// For example, to align the client area to the lower-right corner, return the WVR_ALIGNRIGHT and WVR_ALIGNBOTTOM values.
+		/// <summary>
+		WVR_ALIGNRIGHT = 0x080,
+		
+		/// <summary>
+		/// Used in combination with any other values, except WVR_VALIDRECTS, causes the window to be completely redrawn if the client rectangle changes size horizontally.
+		/// This value is similar to CS_HREDRAW class style
+		/// <summary>
+		WVR_HREDRAW = 0x100,
+		
+		/// <summary>
+		/// Used in combination with any other values, except WVR_VALIDRECTS, causes the window to be completely redrawn if the client rectangle changes size vertically.
+		/// This value is similar to CS_VREDRAW class style
+		/// <summary>
+		WVR_VREDRAW = 0x200,
+		
+		/// <summary>
+		/// Used in combination with any other values, except WVR_VALIDRECTS, causes the window to be completely redrawn if the client rectangle changes size vertically.
+		/// This value is similar to CS_VREDRAW class style
+		/// <summary>
+		WVR_REDRAW = 0x300,
+		
+		/// <summary>
+		/// This value indicates that, upon return from WM_NCCALCSIZE, the rectangles specified by the rgrc[1] and rgrc[2] members of the NCCALCSIZE_PARAMS structure
+		/// contain valid destination and source area rectangles, respectively.
+		/// The system combines these rectangles to calculate the area of the window to be preserved.
+		/// The system copies any part of the window image that is within the source rectangle and clips the image to the destination rectangle.
+		/// Both rectangles are in parent-relative or screen-relative coordinates.
+		/// This flag cannot be combined with any other flags.
+		///
+		/// This return value allows an application to implement more elaborate client-area preservation strategies, such as centering or preserving a subset of the client area.
+		/// <summary>
+		WVR_VALIDRECTS = 0x400
+	}
+}

--- a/source/MetroRadiance.Core/MetroRadiance.Core.csproj
+++ b/source/MetroRadiance.Core/MetroRadiance.Core.csproj
@@ -44,10 +44,16 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Interop\Appbar.cs" />
     <Compile Include="Interop\Dpi.cs" />
+    <Compile Include="Interop\Win32\APPBARDATA.cs" />
+    <Compile Include="Interop\Win32\AppBarEdges.cs" />
+    <Compile Include="Interop\Win32\AppBarMessages.cs" />
+    <Compile Include="Interop\Win32\AppBarStates.cs" />
     <Compile Include="Interop\Win32\MONITORINFOEX.cs" />
     <Compile Include="Interop\Win32\NCCALCSIZE_PARAMS.cs" />
     <Compile Include="Interop\Win32\WindowValidRects.cs" />
+    <Compile Include="Interop\Win32\Shell32.cs" />
     <Compile Include="Platform\ImmersiveColor.cs" />
     <Compile Include="Interop\InteropExtensions.cs" />
     <Compile Include="Interop\MonitorDpiType.cs" />

--- a/source/MetroRadiance.Core/MetroRadiance.Core.csproj
+++ b/source/MetroRadiance.Core/MetroRadiance.Core.csproj
@@ -45,6 +45,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Interop\Dpi.cs" />
+    <Compile Include="Interop\Win32\MONITORINFOEX.cs" />
+    <Compile Include="Interop\Win32\NCCALCSIZE_PARAMS.cs" />
+    <Compile Include="Interop\Win32\WindowValidRects.cs" />
     <Compile Include="Platform\ImmersiveColor.cs" />
     <Compile Include="Interop\InteropExtensions.cs" />
     <Compile Include="Interop\MonitorDpiType.cs" />

--- a/source/MetroRadiance/Themes/Generic.MetroWindow.xaml
+++ b/source/MetroRadiance/Themes/Generic.MetroWindow.xaml
@@ -62,13 +62,6 @@
 			</Setter.Value>
 		</Setter>
 		<Style.Triggers>
-			<Trigger Property="WindowState"
-					 Value="Maximized">
-				<Setter Property="BorderThickness"
-						Value="0" />
-				<Setter Property="Padding"
-						Value="8" />
-			</Trigger>
 			<Trigger Property="IsActive"
 					 Value="False">
 				<Setter Property="BorderBrush"

--- a/source/MetroRadiance/UI/Controls/MetroWindow.cs
+++ b/source/MetroRadiance/UI/Controls/MetroWindow.cs
@@ -310,6 +310,8 @@ namespace MetroRadiance.UI.Controls
 			if (!User32.GetMonitorInfo(hMonitor, ref monitorInfo)) return IntPtr.Zero;
 
 			var workArea = monitorInfo.rcWork;
+			AppBar.ApplyAppbarSpace(monitorInfo.rcMonitor, ref workArea);
+
 			rcsize.rgrc[0] = workArea;
 			rcsize.rgrc[1] = workArea;
 			Marshal.StructureToPtr(rcsize, lParam, true);


### PR DESCRIPTION
- Fix a problem to show space on high DPI. As below:
  <img width="484" alt="スクリーンショット 2020-08-02 14 32 41" src="https://user-images.githubusercontent.com/901816/89116282-168dd700-d4cd-11ea-9623-8350408b33b5.png">
  Since the size of the margins varies depending on the DPI, I fixed this problem by adjusting the client area when the window is maximized. Fixed as below:
  <img width="374" alt="スクリーンショット 2020-08-02 15 48 41" src="https://user-images.githubusercontent.com/901816/89117345-eef03c00-d4d7-11ea-8b65-8995981b1314.png">
- Fix #20 (It is that the taskbar isn't automatically hidden when the window is maximized).

---

(以下の日本語は英語と同じ内容です)

- High DPI環境でウィンドウの周辺に余白が表示される問題。
  <img width="484" alt="スクリーンショット 2020-08-02 14 32 41" src="https://user-images.githubusercontent.com/901816/89116282-168dd700-d4cd-11ea-9623-8350408b33b5.png">
  DPIによって余白の大きさが異なるため，最大化時のクライアント領域を調整することによってこの問題を修正しました。修正後:
  <img width="374" alt="スクリーンショット 2020-08-02 15 48 41" src="https://user-images.githubusercontent.com/901816/89117345-eef03c00-d4d7-11ea-8b65-8995981b1314.png">
- #20 の修正。
