### PR TITLE
Improve theme support.

### DIFF
--- a/samples/MetroRadiance.Showcase/app.manifest
+++ b/samples/MetroRadiance.Showcase/app.manifest
@@ -34,13 +34,13 @@
       <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
 
       <!-- Windows 8 -->
-      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
 
       <!-- Windows 8.1 -->
-      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
 
       <!-- Windows 10 -->
-      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
 
     </application>
   </compatibility>

--- a/source/MetroRadiance.Core/Interop/Win32/Dwmapi.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/Dwmapi.cs
@@ -7,8 +7,8 @@ namespace MetroRadiance.Interop.Win32
 {
 	public static class Dwmapi
 	{
-		[DllImport("Dwmapi.dll")]
-		public static extern void DwmGetColorizationColor([Out] out int pcrColorization, [Out] out bool pfOpaqueBlend);
+		[DllImport("Dwmapi.dll", ExactSpelling = true)]
+		public static extern void DwmGetColorizationColor([Out] out uint pcrColorization, [Out, MarshalAs(UnmanagedType.Bool)] out bool pfOpaqueBlend);
 
 		[DllImport("Dwmapi.dll")]
 		public static extern void DwmGetWindowAttribute(IntPtr hWnd, DWMWINDOWATTRIBUTE dwAttribute, [Out] out RECT pvAttribute, int cbAttribute);

--- a/source/MetroRadiance.Core/Media/ColorHelper.cs
+++ b/source/MetroRadiance.Core/Media/ColorHelper.cs
@@ -16,7 +16,7 @@ namespace MetroRadiance.Media
 			return HsvColor.FromRgb(c);
 		}
 
-		public static Color GetColorFromInt64(long color)
+		public static Color GetColorFromUInt32(uint color)
 		{
 			return Color.FromArgb((byte)(color >> 24), (byte)(color >> 16), (byte)(color >> 8), (byte)color);
 		}

--- a/source/MetroRadiance.Core/MetroRadiance.Core.csproj
+++ b/source/MetroRadiance.Core/MetroRadiance.Core.csproj
@@ -55,7 +55,9 @@
     <Compile Include="Media\ColorHelper.cs" />
     <Compile Include="Media\HsvColor.cs" />
     <Compile Include="Media\Luminosity.cs" />
+    <Compile Include="Platform\IWindowsThemeValue.cs" />
     <Compile Include="Platform\WindowComposition.cs" />
+    <Compile Include="Platform\WindowsThemeConstantValue.cs" />
     <Compile Include="Platform\WindowsThemeValues.cs" />
     <Compile Include="Platform\TransparentWindow.cs" />
     <Compile Include="Platform\WindowsThemeValue.cs" />

--- a/source/MetroRadiance.Core/Platform/IWindowsThemeValue.cs
+++ b/source/MetroRadiance.Core/Platform/IWindowsThemeValue.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.ComponentModel;
+using MetroRadiance.Utilities;
+
+namespace MetroRadiance.Platform
+{
+	public interface IWindowsThemeValue<T>
+	{
+		/// <summary>
+		/// 設定値が動的に変更されるかを取得します。
+		/// </summary>
+		bool IsDynamic { get; }
+
+		/// <summary>
+		/// 現在の設定値を取得します。
+		/// </summary>
+		T Current { get; }
+
+		/// <summary>
+		/// テーマ設定が変更されると発生します。
+		/// </summary>
+		event EventHandler<T> Changed;
+	}
+
+	public static class IWindowsThemeValueExtensions
+	{
+		/// <summary>
+		/// テーマ設定が変更されたときに通知を受け取るメソッドを登録します。
+		/// </summary>
+		/// <param name="callback">テーマ設定が変更されたときに通知を受け取るメソッド。</param>
+		/// <returns>通知の購読を解除するときに使用する <see cref="IDisposable"/> オブジェクト。</returns>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static IDisposable RegisterListener<T>(this IWindowsThemeValue<T> that, Action<T> callback)
+		{
+			EventHandler<T> handler = (sender, e) => callback?.Invoke(e);
+			that.Changed += handler;
+
+			return Disposable.Create(() => that.Changed -= handler);
+		}
+	}
+}

--- a/source/MetroRadiance.Core/Platform/WindowsTheme.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsTheme.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Media;
 
 namespace MetroRadiance.Platform
 {
@@ -10,25 +11,65 @@ namespace MetroRadiance.Platform
 	/// </summary>
 	public static class WindowsTheme
 	{
+		static WindowsTheme()
+		{
+			var version = Environment.OSVersion.Version;
+			if (version.Major == 10)
+			{
+				if (version.Build >= 18282)
+				{
+					Theme = new ThemeValue();
+					SystemTheme = new SystemThemeValue();
+				}
+				else if (version.Build >= 14316)
+				{
+					Theme = new ThemeValue();
+					SystemTheme = new WindowsThemeConstantValue<Theme>(Platform.Theme.Dark);
+				}
+				else
+				{
+					Theme = new WindowsThemeConstantValue<Theme>(Platform.Theme.Light);
+					SystemTheme = new WindowsThemeConstantValue<Theme>(Platform.Theme.Dark);
+				}
+				ColorPrevalence = new ColorPrevalenceValue();
+				Transparency = new TransparencyValueWindows10();
+			}
+			else
+			{
+				Theme = new WindowsThemeConstantValue<Theme>(Platform.Theme.Light);
+				SystemTheme = new WindowsThemeConstantValue<Theme>(Platform.Theme.Light);
+				ColorPrevalence = new WindowsThemeConstantValue<bool>(true);
+				if (version.Major == 6 && version.Minor == 0
+					|| version.Major == 6 && version.Minor == 1)
+				{
+					Transparency = new TransparencyValueWindowsVistaOr7();
+				}
+				else
+				{
+					Transparency = new WindowsThemeConstantValue<bool>(false);
+				}
+			}
+		}
+
 		/// <summary>
 		/// Windows の既定のアプリテーマ設定と、その変更通知機能へアクセスできるようにします。
 		/// </summary>
-		public static ThemeValue Theme { get; } = new ThemeValue();
+		public static IWindowsThemeValue<Theme> Theme { get; }
 
 		/// <summary>
 		/// Windows の既定のシステムテーマ設定と、その変更通知機能へアクセスできるようにします。
 		/// </summary>
-		public static SystemThemeValue SystemTheme { get; } = new SystemThemeValue();
+		public static IWindowsThemeValue<Theme> SystemTheme { get; }
 
 		/// <summary>
 		/// Windows のアクセント カラー設定と、その変更通知機能へアクセスできるようにします。
 		/// </summary>
-		public static AccentValue Accent { get; } = new AccentValue();
+		public static IWindowsThemeValue<Color> Accent { get; } = new AccentValue();
 
-		public static HighContrastValue HighContrast { get; } = new HighContrastValue();
+		public static IWindowsThemeValue<bool> HighContrast { get; } = new HighContrastValue();
 
-		public static ColorPrevalenceValue ColorPrevalence { get; } = new ColorPrevalenceValue();
+		public static IWindowsThemeValue<bool> ColorPrevalence { get; }
 
-		public static TransparencyValue Transparency { get; } = new TransparencyValue();
+		public static IWindowsThemeValue<bool> Transparency { get; }
 	}
 }

--- a/source/MetroRadiance.Core/Platform/WindowsTheme.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsTheme.cs
@@ -71,5 +71,10 @@ namespace MetroRadiance.Platform
 		public static IWindowsThemeValue<bool> ColorPrevalence { get; }
 
 		public static IWindowsThemeValue<bool> Transparency { get; }
+		
+		/// <summary>
+		/// Windows の文字の大きさ設定と、その変更通知機能へアクセスできるようにします。
+		/// </summary>
+		public static IWindowsThemeValue<double> TextScaleFactor { get; } = new TextScaleFactorValue();
 	}
 }

--- a/source/MetroRadiance.Core/Platform/WindowsThemeConstantValue.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsThemeConstantValue.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace MetroRadiance.Platform
+{
+	public sealed class WindowsThemeConstantValue<T> : IWindowsThemeValue<T>
+	{
+		internal WindowsThemeConstantValue(T constant)
+		{
+			this.Current = constant;
+		}
+
+		/// <summary>
+		/// 設定値が動的に変更されるかを取得します。
+		/// </summary>
+		public bool IsDynamic => false;
+
+		/// <summary>
+		/// 現在の設定値を取得します。
+		/// </summary>
+		public T Current { get; }
+
+		/// <summary>
+		/// テーマ設定が変更されると発生します。
+		/// </summary>
+		public event EventHandler<T> Changed;
+	}
+}

--- a/source/MetroRadiance.Core/Platform/WindowsThemeValue.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsThemeValue.cs
@@ -8,7 +8,7 @@ using MetroRadiance.Utilities;
 
 namespace MetroRadiance.Platform
 {
-	public abstract class WindowsThemeValue<T>
+	public abstract class WindowsThemeValue<T> : IWindowsThemeValue<T>
 	{
 		private event EventHandler<T> _changedEvent;
 		private readonly HashSet<EventHandler<T>> _handlers = new HashSet<EventHandler<T>>();
@@ -17,6 +17,11 @@ namespace MetroRadiance.Platform
 		private bool _hasCache;
 
 		private bool RequireCallGetValue => !this._hasCache || this._listenerWindow == null;
+
+		/// <summary>
+		/// 設定値が動的に変更されるかを取得します。
+		/// </summary>
+		public bool IsDynamic => false;
 
 		/// <summary>
 		/// 現在の設定値を取得します。
@@ -33,7 +38,7 @@ namespace MetroRadiance.Platform
 
 				return this._current;
 			}
-			set
+			protected set
 			{
 				this._current = value;
 				this._hasCache = true;
@@ -47,20 +52,6 @@ namespace MetroRadiance.Platform
 		{
 			add { this.Add(value); }
 			remove { this.Remove(value); }
-		}
-
-		/// <summary>
-		/// テーマ設定が変更されたときに通知を受け取るメソッドを登録します。
-		/// </summary>
-		/// <param name="callback">テーマ設定が変更されたときに通知を受け取るメソッド。</param>
-		/// <returns>通知の購読を解除するときに使用する <see cref="IDisposable"/> オブジェクト。</returns>
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public IDisposable RegisterListener(Action<T> callback)
-		{
-			EventHandler<T> handler = (sender, e) => callback?.Invoke(e);
-			this.Changed += handler;
-
-			return Disposable.Create(() => this.Changed -= handler);
 		}
 
 		private void Add(EventHandler<T> listener)
@@ -92,15 +83,15 @@ namespace MetroRadiance.Platform
 			}
 		}
 
-		internal void Update(T data)
+		protected void Update(T data)
 		{
 			this.Current = data;
 			this._changedEvent?.Invoke(this, data);
 		}
 
-		internal abstract T GetValue();
+		protected abstract T GetValue();
 
-		internal abstract IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled);
+		protected abstract IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled);
 
 		private class ListenerWindow : TransparentWindow
 		{

--- a/source/MetroRadiance.Core/Platform/WindowsThemeValues.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsThemeValues.cs
@@ -178,4 +178,30 @@ namespace MetroRadiance.Platform
 			return IntPtr.Zero;
 		}
 	}
+
+	internal sealed class TextScaleFactorValue : WindowsThemeValue<double>
+	{
+		protected override double GetValue()
+		{
+			const string keyName = @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Accessibility";
+			const string valueName = "TextScaleFactor";
+
+			return (Registry.GetValue(keyName, valueName, null) as int? ?? 100) / 100.0;
+		}
+
+		protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+		{
+			if (msg == (int)WindowsMessages.WM_SETTINGCHANGE)
+			{
+				var systemParmeter = Marshal.PtrToStringAuto(lParam);
+				if (systemParmeter == "WindowsThemeElement")
+				{
+					this.Update(this.GetValue());
+					handled = true;
+				}
+			}
+
+			return IntPtr.Zero;
+		}
+	}
 }

--- a/source/MetroRadiance.Core/Platform/WindowsThemeValues.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsThemeValues.cs
@@ -15,9 +15,9 @@ namespace MetroRadiance.Platform
 		Light = 1,
 	}
 
-	public class ThemeValue : WindowsThemeValue<Theme>
+	internal class ThemeValue : WindowsThemeValue<Theme>
 	{
-		internal override Theme GetValue()
+		protected override Theme GetValue()
 		{
 			const string keyName = @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
 			const string valueName = "AppsUseLightTheme";
@@ -25,7 +25,7 @@ namespace MetroRadiance.Platform
 			return Registry.GetValue(keyName, valueName, null) as int? == 0 ? Theme.Dark : Theme.Light;
 		}
 
-		internal override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+		protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
 		{
 			if (msg == (int)WindowsMessages.WM_SETTINGCHANGE)
 			{
@@ -41,9 +41,9 @@ namespace MetroRadiance.Platform
 		}
 	}
 
-	public class SystemThemeValue : ThemeValue
+	internal sealed class SystemThemeValue : ThemeValue
 	{
-		internal override Theme GetValue()
+		protected override Theme GetValue()
 		{
 			const string keyName = @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
 			const string valueName = "SystemUsesLightTheme";
@@ -52,34 +52,34 @@ namespace MetroRadiance.Platform
 		}
 	}
 
-	public class AccentValue : WindowsThemeValue<Color>
+	internal sealed class AccentValue : WindowsThemeValue<Color>
 	{
-		internal override Color GetValue()
+		protected override Color GetValue()
 		{
 			const string keyName = @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\DWM";
 			const string valueName = "ColorizationColor";
-			int color;
+			uint color;
 
 			var colorizationColor = Registry.GetValue(keyName, valueName, null) as int?;
 			if (colorizationColor != null)
 			{
-				color = colorizationColor.Value;
+				color = (uint)colorizationColor.Value;
 			}
 			else
 			{
 				bool opaque;
+				// Note: return the modified value on Windows Vista & 7
 				Dwmapi.DwmGetColorizationColor(out color, out opaque);
 			}
 
-			return ColorHelper.GetColorFromInt64(color);
+			return ColorHelper.GetColorFromUInt32(color);
 		}
 
-		internal override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+		protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
 		{
 			if (msg == (int)WindowsMessages.WM_DWMCOLORIZATIONCOLORCHANGED)
 			{
-				var color = ColorHelper.GetColorFromInt64((long)wParam);
-				this.Update(color);
+				this.Update(this.GetValue());
 				handled = true;
 			}
 
@@ -88,11 +88,11 @@ namespace MetroRadiance.Platform
 	}
 
 
-	public sealed class HighContrastValue : WindowsThemeValue<bool>
+	internal sealed class HighContrastValue : WindowsThemeValue<bool>
 	{
-		internal override bool GetValue() => System.Windows.SystemParameters.HighContrast;
+		protected override bool GetValue() => System.Windows.SystemParameters.HighContrast;
 
-		internal override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+		protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
 		{
 			if (msg == (int)WindowsMessages.WM_THEMECHANGED)
 			{
@@ -104,9 +104,9 @@ namespace MetroRadiance.Platform
 		}
 	}
 
-	public sealed class ColorPrevalenceValue : WindowsThemeValue<bool>
+	internal sealed class ColorPrevalenceValue : WindowsThemeValue<bool>
 	{
-		internal override bool GetValue()
+		protected override bool GetValue()
 		{
 			const string keyName = @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
 			const string valueName = "ColorPrevalence";
@@ -114,7 +114,7 @@ namespace MetroRadiance.Platform
 			return Registry.GetValue(keyName, valueName, null) as int? != 0;
 		}
 
-		internal override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+		protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
 		{
 			if (msg == (int)WindowsMessages.WM_SETTINGCHANGE)
 			{
@@ -130,9 +130,9 @@ namespace MetroRadiance.Platform
 		}
 	}
 
-	public sealed class TransparencyValue : WindowsThemeValue<bool>
+	internal sealed class TransparencyValueWindows10 : WindowsThemeValue<bool>
 	{
-		internal override bool GetValue()
+		protected override bool GetValue()
 		{
 			const string keyName = @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
 			const string valueName = "EnableTransparency";
@@ -140,7 +140,7 @@ namespace MetroRadiance.Platform
 			return Registry.GetValue(keyName, valueName, null) as int? != 0;
 		}
 
-		internal override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+		protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
 		{
 			if (msg == (int)WindowsMessages.WM_SETTINGCHANGE)
 			{
@@ -150,6 +150,29 @@ namespace MetroRadiance.Platform
 					this.Update(this.GetValue());
 					handled = true;
 				}
+			}
+
+			return IntPtr.Zero;
+		}
+	}
+
+	internal sealed class TransparencyValueWindowsVistaOr7 : WindowsThemeValue<bool>
+	{
+		protected override bool GetValue()
+		{
+			uint color;
+			bool opaque;
+			Dwmapi.DwmGetColorizationColor(out color, out opaque);
+			return opaque;
+		}
+
+		protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+		{
+			if (msg == (int)WindowsMessages.WM_DWMCOLORIZATIONCOLORCHANGED)
+			{
+				var opaque = Convert.ToBoolean((long)lParam);
+				this.Update(opaque);
+				handled = true;
 			}
 
 			return IntPtr.Zero;


### PR DESCRIPTION
- Fix issue to apply invalid accent color after invoked `WM_DWMCOLORIZATIONCOLORCHANGED` on Windows 7 (maybe also Vista).
- Add opaque value support for Windows Vista & 7
- Use constant value for older Windows 10.
- Added a function to get and notify the change of the "Make text bigger" setting.
  <img src="https://user-images.githubusercontent.com/901816/88556485-0a84be00-d064-11ea-9eae-e41d0fd0527b.png" width="420" alt="display-maketextbigger">