### PR TITLE
Fix Per-monitor DPI bug

### DIFF
--- a/samples/MetroRadiance.Showcase/app.manifest
+++ b/samples/MetroRadiance.Showcase/app.manifest
@@ -49,13 +49,13 @@
        DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
        to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
-  
-  <!--<application xmlns="urn:schemas-microsoft-com:asm.v3">
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
     </windowsSettings>
-  </application>-->
-  
+  </application>
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--

--- a/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
+++ b/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
@@ -326,16 +326,19 @@ namespace MetroRadiance.Chrome.Primitives
 				return new IntPtr(3);
 			}
 
-			//if (msg == (int)WindowsMessages.WM_DPICHANGED)
-			//{
+			#if NET40 || NET45 || NET451 || NET452 || NET46 || NET461
+			// Note: Double scaling is avoided on .NET Framework 4.6.2 or later.
+			if (msg == (int)WindowsMessages.WM_DPICHANGED)
+			{
 			//	System.Diagnostics.Debug.WriteLine("WM_DPICHANGED: " + this.GetType().Name);
 
 			//	var dpiX = wParam.ToLoWord();
 			//	var dpiY = wParam.ToHiWord();
 			//	this.ChangeDpi(new Dpi(dpiX, dpiY));
-			//	handled = true;
-			//	return IntPtr.Zero;
-			//}
+				handled = true;
+				return IntPtr.Zero;
+			}
+			#endif
 
 			return this.WndProcOverride(hwnd, msg, wParam, lParam, ref handled) ?? IntPtr.Zero;
 		}

--- a/source/MetroRadiance.Core/Interop/Win32/User32.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/User32.cs
@@ -32,9 +32,15 @@ namespace MetroRadiance.Interop.Win32
 			return (WindowExStyles)SetWindowLong(hWnd, (int)WindowLongFlags.GWL_EXSTYLE, (int)dwNewLong);
 		}
 
-		[DllImport("user32.dll")]
+		[DllImport("user32.dll", EntryPoint = "SetWindowPos", SetLastError = true, ExactSpelling = true)]
 		[return: MarshalAs(UnmanagedType.Bool)]
-		public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, SetWindowPosFlags flags);
+		private static extern bool _SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, SetWindowPosFlags flags);
+
+		public static void SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, SetWindowPosFlags flags)
+		{
+			var ret = _SetWindowPos(hWnd, hWndInsertAfter, x, y, cx, cy, flags);
+			if (!ret) throw new Win32Exception(Marshal.GetLastWin32Error());
+		}
 
 		[DllImport("user32.dll")]
 		public static extern bool SetWindowPlacement(IntPtr hWnd, [In] ref WINDOWPLACEMENT lpwndpl);

--- a/source/MetroRadiance/Styles/Controls.Tooltip.xaml
+++ b/source/MetroRadiance/Styles/Controls.Tooltip.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:controls="clr-namespace:MetroRadiance.UI.Controls">
 
 	<Style x:Key="{x:Type ToolTip}"
 		   TargetType="ToolTip">
@@ -8,7 +9,7 @@
 		<Setter Property="HasDropShadow"
 				Value="True" />
 		<Setter Property="Foreground"
-				Value="{DynamicResource AccentForegroundBrushKey}" />
+				Value="{DynamicResource ActiveForegroundBrushKey}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="ToolTip">
@@ -17,7 +18,8 @@
 							BorderBrush="{DynamicResource BorderBrushKey}"
 							Background="{DynamicResource BackgroundBrushKey}"
 							Padding="6,4"
-							SnapsToDevicePixels="True">
+							SnapsToDevicePixels="True"
+							LayoutTransform="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:MetroWindow}}, Path=DpiScaleTransform}">
 						<ContentPresenter />
 					</Border>
 				</ControlTemplate>

--- a/source/MetroRadiance/UI/Controls/CaptionIcon.cs
+++ b/source/MetroRadiance/UI/Controls/CaptionIcon.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
+using MetroRadiance.Interop;
 using MetroRadiance.Interop.Win32;
 
 namespace MetroRadiance.UI.Controls
@@ -56,22 +57,18 @@ namespace MetroRadiance.UI.Controls
 
 		protected override void OnMouseDown(MouseButtonEventArgs e)
 		{
-			var window = Window.GetWindow(this) as MetroWindow;
-			if (window == null)
-			{
-				base.OnMouseDown(e);
-				return;
-			}
-
 			if (e.ChangedButton == MouseButton.Left)
 			{
+				var window = Window.GetWindow(this);
 				if (e.ClickCount == 1)
 				{
 					if (!this.isSystemMenuOpened)
 					{
 						this.isSystemMenuOpened = true;
+
 						var point = this.PointToScreen(new Point(0, this.ActualHeight));
-						SystemCommands.ShowSystemMenu(window, new Point(point.X / window.CurrentDpi.ScaleX, point.Y / window.CurrentDpi.ScaleY));
+						var dpi = Dpi.FromVisual(window);
+						SystemCommands.ShowSystemMenu(window, dpi.PhysicalToLogical(point));
 					}
 					else
 					{
@@ -83,19 +80,18 @@ namespace MetroRadiance.UI.Controls
 					window.Close();
 				}
 			}
+			else
+			{
+				base.OnMouseDown(e);
+			}
 		}
 
 		protected override void OnMouseRightButtonUp(MouseButtonEventArgs e)
 		{
-			var window = Window.GetWindow(this) as MetroWindow;
-			if (window == null)
-			{
-				base.OnMouseRightButtonUp(e);
-				return;
-			}
-
+			var window = Window.GetWindow(this);
 			var point = this.PointToScreen(e.GetPosition(this));
-			SystemCommands.ShowSystemMenu(window, new Point(point.X / window.CurrentDpi.ScaleX, point.Y / window.CurrentDpi.ScaleY));
+			var dpi = Dpi.FromVisual(window);
+			SystemCommands.ShowSystemMenu(window, dpi.PhysicalToLogical(point));
 		}
 
 		protected override void OnMouseLeave(MouseEventArgs e)

--- a/source/MetroRadiance/UI/Controls/MetroWindow.cs
+++ b/source/MetroRadiance/UI/Controls/MetroWindow.cs
@@ -155,9 +155,31 @@ namespace MetroRadiance.UI.Controls
 
 			instance.Loaded += (sender, args) =>
 			{
-				var chrome = ShellChrome.GetWindowChrome(window);
-				if (chrome != null) chrome.CaptionHeight = instance.ActualHeight;
+				window.UpdateIsCaptionBarHeight();
 			};
+		}
+
+		private void UpdateIsCaptionBarHeight()
+		{
+			var chrome = ShellChrome.GetWindowChrome(this);
+			if (chrome == null) return;
+
+			var captionBar = this.captionBar;
+			if (captionBar != null)
+			{
+				if (this.systemDpi.Y > 0)
+				{
+					chrome.CaptionHeight = captionBar.ActualHeight * this.CurrentDpi.Y / this.systemDpi.Y;
+				}
+				else
+				{
+					chrome.CaptionHeight = captionBar.ActualHeight;
+				}
+			}
+			else
+			{
+				chrome.CaptionHeight = 0;
+			}
 		}
 
 		#endregion
@@ -331,6 +353,8 @@ namespace MetroRadiance.UI.Controls
 			this.Height = this.Height * dpi.Y / this.CurrentDpi.Y;
 
 			this.CurrentDpi = dpi;
+
+			this.UpdateIsCaptionBarHeight();
 		}
 	}
 }


### PR DESCRIPTION
### Changes

- General
  - Add Per-monitor DPI v1, v2 support to manifest of showcase app.
  - Add a utility method to struct `DPI`.
  - <s>Support for new functions for DPI support (`GetDpiForSystem`, `GetDpiForWindow` from Windows 10 Anniversary Update [1607]).</s>
  - <s>(Specification modified) Change to return that the Per-monitor DPI isn't supported by the library if the process isn't Per-monitor DPI mode in the Per-monitor DPI v1 environment.</s>
- for .NET Framework 4.0〜4.6.1
  - Fix per-monitor DPI scaling
    - system menus position for `CaptionIcon`
    - Added per-monitor DPI support for `Tooltip` and changed its foreground brush (`AccentForegroundBrushKey` → `ActiveForegroundBrushKey`).
    - <s>Popup scaling for `PromptComboBox`</s> (Note 4)
    - **CaptionBar height**
      ![2020-08-11-21-41-45_Trim](https://user-images.githubusercontent.com/901816/89899545-6d0dba80-dc1d-11ea-8c7a-1ae72cfd3723.gif)
      - This is a serious bug to disallow hittest to content area when system DPI > monitor/window DPI.
  - When DPI is switched after dragging the window frame, the window is moved away from the bottom of the pointer.
- for .NET Framework 4.6.2〜4.8 / .NET Core 3.0, 3.1 / .NET 5
  - <s>Make use of the Per-monitor DPI implementation of WPF. MetroRadiance doesn't do anything.</s>
  - <s>Per-monitor DPI isn't available on Windows 8.1, Windows 10 TH1, and TH2.</s>
  - (with .NET Framework 4.6.1 and earlier builds) A workaround code has been added to prevent `ChromeWindow` from being double-scaled.

#### Notes:
 
1. This PR can move to the new build system. (I test on .NET Framework 4.6 and .NET Core 3.1)
2. I'm not tested on Windows 8.1.
3. Class `DpiHelper` is my favorite. It has nothing to fix the feature.
4. It doesn't seem to reproduce the problem without this patch😔. <s>I'm not sure what the cause is, so I'll do additional investigations.</s>
  ![Popup is bug?](https://user-images.githubusercontent.com/901816/89897135-8c0a4d80-dc19-11ea-9028-fdac38eeba04.png)
  NET Framework 4.6.2 and above, this problem appears to occur when the Per-monitor DPI is enabled in the manifest and `Window` and `Popup` are double-scaled if its library don't have `WM_DPICHANGED` in their app hosts. To reduce the impact, `ChromeWindow` commits with `WM_DPICHANGED` will be supported by this PR.
  However, since the standard `Popup` doesn't work, we recommend that you build `net45` and `net462` separately when you switch to the .NET Core build environment to help you deal with this problem.
  ![metroradiance-chrome-bug](https://user-images.githubusercontent.com/901816/90028504-b54bdc00-dcf4-11ea-991d-03741a360a08.png)

#### Known issues:

- The `ContextMenu` isn't scaled correctly. However, this isn't included in the PR.
  <img width="374" alt="metroradiance-permonitorsupport" src="https://user-images.githubusercontent.com/901816/89879977-a420a380-dbfe-11ea-9d07-12a36c2fa4e9.png">
- When launched outside of system DPI, DPI scaling for the initial Width and Height of an application.
  - NET Core 3.1 has the same problem.
  - There seems to be an issue in the window position/size restoration method on the MetroRadiance side. In all implementations (.NET Framework 4.6.1 or below & 4.6.2 or above), MetroRadiance restores the window position in `OnSourceInitialized` (where `CurrentDpi` is equal to `SystemDpi`). After the window is initialized, the window size is adjusted by a notice of change to the `Window Dpi` with `WM_DPICHANGED`.
  The example of workaround is to save the window as DPI-independent size.
- Is is impossible for WPF on .NET Framework 4.0 − **4.7.2** that the non-client area adjustments supported in the Windows 10 Anniversary Update [1607].
  - The app will need to receive a `WM_NCCREATE` and run `EnableNonClientDpiScaling`. However, the app cannot hook methods before class `Window` is used to create the Can't hook WndProc because `CreateWindowEx` is called in the `HwndWrapper` of WPF.
- There is a bug that causes double scaling of the `Popup` on .NET Framework 4.6.2 and Per-monitor DPI process with using .NET Framework 4.6.1 or earlier builds.
  - .NET Framework 4.6.2 or later, add the following statement to `App.config` to disable built-in scaling.
    ```xml
    <?xml version="1.0" encoding="utf-8" ?>
    <configuration>
      <runtime>
          <AppContextSwitchOverrides value="Switch.System.Windows.DoNotScaleForDpiChanges=true" />
      </runtime>
    </configuration>
    ```
    However, the app developer must request it.

---

### 変更点

- 全般
  - Showcase のマニフェストに Per-monitor DPI v1, v2 対応の記述を追加。
  - `DPI` 構造体に関数の追加。
  - <s>新しい DPI サポートのための関数に対応 (Windows 10 Anniversary Update [1607] から使える `GetDpiForSystem`, `GetDpiForWindow`)。</s>
  - <s>(仕様変更) Per-monitor DPI v1 環境でプロセスが Per-monitor DPI モードでない場合，ライブラリーが Per-monitor DPI に対応していないと返すように変更。</s>
- .NET Framework 4.0〜4.6.1 向け
  - 一部の要素で正しく Per-monitor DPI で計算されない (System DPI のまま計算される) 不具合。
    - `CaptionIcon` のシステム メニューのポップアップ位置
    - `Tooltip` の Per-monitor DPI サポートおよび文字色 (`AccentForegroundBrushKey` → `ActiveForegroundBrushKey`) の変更。
    - <s>`PromptComboBox` の Popup 部分</s> (注意4)
    - **CaptionBar の範囲**
      ![2020-08-11-21-41-45_Trim](https://user-images.githubusercontent.com/901816/89899545-6d0dba80-dc1d-11ea-8c7a-1ae72cfd3723.gif)
      - system DPI > monitor/window DPI 時コンテンツエリアにヒットテストが通らない深刻な不具合です
  - ウィンドウ枠をドラッグしたタイミングで DPI が切り替わると，ウィンドウサイズがポインターの直下から離れてしまう不具合。
- .NET Framework 4.6.2〜4.8 / .NET Core 3.0, 3.1 / .NET 5
  - <s>WPF 自体の Per-monitor DPI 実装を活用し，MetroRadiance 側では何もしないように変更を加えています。</s>
  - <s>Windows 8.1 や Windows 10 TH1, TH2 では Per-monitor DPI が利用できなくなります。</s>
  - (.NET Framework 4.6.1以前のビルドを利用した場合) `ChromeWindow` が 2 重スケーリングされないように回避コードを入れました。

#### 注意:

1. この PR は新ビルドシステム移行を考慮しています (テストしているのは .NET Framework 4.6 と .NET Core 3.1 です)。
2. Windows 8.1 環境でテストしていません。
3. `DpiHelper` の実装は完全に趣味の領域なので，なくても問題なく動作します。
4. このパッチがなくても不具合再現しないっぽいですね😔。<s>原因がよくわからないので追加調査します。</s>
  ![Popup is bug?](https://user-images.githubusercontent.com/901816/89897135-8c0a4d80-dc19-11ea-9028-fdac38eeba04.png)
  この不具合は .NET Framework 4.6.2 以上のアプリホストで，Per-monitor DPI をマニフェストで有効にして `WM_DPICHANGED` を捉えていない `Window` や `Popup` が 2 重にスケーリングされることで発生する模様です。影響範囲を狭めるものとして，`ChromeWindow` で `WM_DPICHANGED` を捉えるコミットもこの PR で対応できるようにします。
  ただし，標準 `Popup` は対応できないため，.NET Core ビルド環境に移行時に `net45` と `net462` を別々にビルドしていただけるとこの問題に正しく対処できます。
  ![metroradiance-chrome-bug](https://user-images.githubusercontent.com/901816/90028504-b54bdc00-dcf4-11ea-991d-03741a360a08.png)


#### 既知の不具合:

- `ContextMenu` が正しくスケーリングされていない不具合も存在しています。ただし，この PR に修正は含まれていません。
  <img width="374" alt="metroradiance-permonitorsupport" src="https://user-images.githubusercontent.com/901816/89879977-a420a380-dbfe-11ea-9d07-12a36c2fa4e9.png">
- アプリケーションを system DPI 以外の場所で起動した場合，初期値の Width, Height に対して DPI スケーリングが行われる不具合。
  - .NET Core 3.1 でも同様の症状が見られました。
  - MetroRadiance 側のウィンドウ位置/サイズ復元機構の不具合のようです。全ての実装 (.NET Framework 4.6.1以前でも4.6.2以降でも) で，`OnSourceInitialized` でウィンドウの位置が復元される (このとき `CurrentDpi` は `SystemDpi` に一致)。ウィンドウの初期化が終わると，`WM_DPICHANGED` で実際の `Window Dpi` への変更通知が来ることにより，復元したウィンドウサイズに DPI 変換が行われる模様。
  回避方法は，DPI 非依存のサイズで保存するとかでしょうか？
- Windows 10 Anniversary Update [1607] で対応した非クライアントエリア領域の調整は，.NET Framework 4.0〜**4.7.2** で対応できません。
  - `WM_NCCREATE` を受け取り `EnableNonClientDpiScaling` を実行する必要がありますが，WPF の `HwndWrapper` 内で `CreateWindowEx` が呼ばれますが，この API が呼ばれる前に Window クラスを使って WndProc をフックすることができません。
- .NET Framework 4.6.1以前のビルドを .NET Framework 4.6.2以降のビルドで利用し，かつ Per-monitor DPI 環境で実行していると，`Popup` が 2重でスケーリングされる不具合があります。
  - .NET Framework 4.6.2 以降の Built-in scaling を無効化する場合，`App.config` に
    ```xml
    <?xml version="1.0" encoding="utf-8" ?>
    <configuration>
      <runtime>
          <AppContextSwitchOverrides value="Switch.System.Windows.DoNotScaleForDpiChanges=true" />
      </runtime>
    </configuration>
    ```
    と記述すれば OK です。ただし，アプリ開発者による指定が必要です。