### PR TITLE
Fix theme bug

### DIFF
--- a/source/MetroRadiance.Core/Interop/Win32/Dwmapi.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/Dwmapi.cs
@@ -7,10 +7,10 @@ namespace MetroRadiance.Interop.Win32
 {
 	public static class Dwmapi
 	{
-		[DllImport("Dwmapi.dll", ExactSpelling = true)]
+		[DllImport("Dwmapi.dll", ExactSpelling = true, PreserveSig = false)]
 		public static extern void DwmGetColorizationColor([Out] out uint pcrColorization, [Out, MarshalAs(UnmanagedType.Bool)] out bool pfOpaqueBlend);
 
-		[DllImport("Dwmapi.dll")]
+		[DllImport("Dwmapi.dll", ExactSpelling = true, PreserveSig = false)]
 		public static extern void DwmGetWindowAttribute(IntPtr hWnd, DWMWINDOWATTRIBUTE dwAttribute, [Out] out RECT pvAttribute, int cbAttribute);
 
 	}

--- a/source/MetroRadiance.Core/Platform/WindowsThemeConstantValue.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsThemeConstantValue.cs
@@ -22,6 +22,8 @@ namespace MetroRadiance.Platform
 		/// <summary>
 		/// テーマ設定が変更されると発生します。
 		/// </summary>
+		#pragma warning disable 67
 		public event EventHandler<T> Changed;
+		#pragma warning restore 67
 	}
 }

--- a/source/MetroRadiance.Core/Platform/WindowsThemeValue.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsThemeValue.cs
@@ -21,7 +21,7 @@ namespace MetroRadiance.Platform
 		/// <summary>
 		/// 設定値が動的に変更されるかを取得します。
 		/// </summary>
-		public bool IsDynamic => false;
+		public bool IsDynamic => true;
 
 		/// <summary>
 		/// 現在の設定値を取得します。

--- a/source/MetroRadiance.Core/Platform/WindowsThemeValues.cs
+++ b/source/MetroRadiance.Core/Platform/WindowsThemeValues.cs
@@ -163,7 +163,7 @@ namespace MetroRadiance.Platform
 			uint color;
 			bool opaque;
 			Dwmapi.DwmGetColorizationColor(out color, out opaque);
-			return opaque;
+			return !opaque;
 		}
 
 		protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
@@ -171,7 +171,7 @@ namespace MetroRadiance.Platform
 			if (msg == (int)WindowsMessages.WM_DWMCOLORIZATIONCOLORCHANGED)
 			{
 				var opaque = Convert.ToBoolean((long)lParam);
-				this.Update(opaque);
+				this.Update(!opaque);
 				handled = true;
 			}
 


### PR DESCRIPTION
### Changes

- Fixed an issue that `WindowsTheme.Transparency` doesn't return the correct value on Windows Vista and 7.
- Fixed an issue that `WindowsThemeValue.IsDynamic` doesn't return `true`.
- Suppress the warnings on the build of `WindowsConstantThemeValue`.
- Fixed an issue that HRESULT returned by DWMAPI isn't converted.

---

### 変更点

- Windows Vista や 7 で `WindowsTheme.Transparency` が正しい値を返していなかった問題の修正。
- `WindowsThemeValue.IsDynamic` が `true` を返していなかった問題の修正。
- `WindowsConstantThemeValue` の使用していないイベント `Changed` がビルド時に警告を出ないように修正。
- DWMAPI が返す HRESULT が正しく変換されていない問題の修正。