### PR TITLE
Fix ChromeWindow bug.

### DIFF
--- a/samples/MetroRadiance.Showcase/MetroRadiance.Showcase.csproj
+++ b/samples/MetroRadiance.Showcase/MetroRadiance.Showcase.csproj
@@ -97,6 +97,9 @@
     <Compile Include="UI\BlurWindowSample.xaml.cs">
       <DependentUpon>BlurWindowSample.xaml</DependentUpon>
     </Compile>
+    <Compile Include="UI\ExternalChromeSamples.xaml.cs">
+      <DependentUpon>ExternalChromeSamples.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UI\ImmersiveColorSamples.xaml.cs">
       <DependentUpon>ImmersiveColorSamples.xaml</DependentUpon>
     </Compile>
@@ -110,6 +113,10 @@
     <Page Include="UI\BlurWindowSample.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UI\ExternalChromeSamples.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="UI\ImmersiveColorSamples.xaml">
       <SubType>Designer</SubType>

--- a/samples/MetroRadiance.Showcase/UI/ExternalChromeSamples.xaml
+++ b/samples/MetroRadiance.Showcase/UI/ExternalChromeSamples.xaml
@@ -1,0 +1,71 @@
+﻿<UserControl x:Class="MetroRadiance.Showcase.UI.ExternalChromeSamples"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignWidth="300"
+             d:DesignHeight="300">
+    <DockPanel>
+        <TextBlock DockPanel.Dock="Top"
+                   Text="Windows"
+                   FontFamily="Segoe UI Light"
+                   FontSize="18"
+                   Foreground="{DynamicResource ForegroundBrushKey}"
+                   HorizontalAlignment="Center"
+                   Margin="0,0,0,8" />
+        <StackPanel DockPanel.Dock="Bottom"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,0,8,8">
+            <Button Margin="8,0,0,0"
+                    Content="Refresh"
+                    Width="100"
+                    Height="30"
+                    HorizontalAlignment="Left"
+                    Click="HandleRefreshClicked" />
+            <Button Margin="8,0,0,0"
+                    Content="Apply"
+                    Width="100"
+                    Height="30"
+                    HorizontalAlignment="Left"
+                    Click="HandleMetroChromeClicked" />
+        </StackPanel>
+        <ListView x:Name="WindowsListView"
+                  Margin="8,0,8,8"
+                  Background="Transparent"
+                  BorderBrush="Transparent"
+                  BorderThickness="0"
+                  ItemsSource="{Binding}"
+                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+            <ListView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel IsItemsHost="True"
+                                            Margin="8,0,8,8" />
+                </ItemsPanelTemplate>
+            </ListView.ItemsPanel>
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <DockPanel>
+                        <Border DockPanel.Dock="Left"
+                                Background="White">
+                            <Image Width="32"
+                                   Height="32"
+                                   Source="{Binding Icon}" />
+                        </Border>
+                        <TextBlock Foreground="{DynamicResource SemiActiveForegroundBrushKey}"
+                                   Margin="12,4"
+                                   VerticalAlignment="Center"
+                                   TextTrimming="CharacterEllipsis">
+                            <Run Foreground="{DynamicResource ActiveForegroundBrushKey}"
+                                 Text="{Binding Title}" />
+                            <Run Text="(PID:" />
+                            <Run Text="{Binding ProcessId, Mode=OneTime}" />
+                            <Run Text=")" />
+                        </TextBlock>
+                    </DockPanel>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </DockPanel>
+</UserControl>

--- a/samples/MetroRadiance.Showcase/UI/ExternalChromeSamples.xaml.cs
+++ b/samples/MetroRadiance.Showcase/UI/ExternalChromeSamples.xaml.cs
@@ -1,0 +1,219 @@
+﻿using Livet;
+using MetroRadiance.Chrome;
+using MetroRadiance.Interop.Win32;
+using MetroRadiance.Platform;
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace MetroRadiance.Showcase.UI
+{
+	public partial class ExternalChromeSamples
+	{
+		private WindowChrome _metroChrome;
+
+		public ExternalChromeSamples()
+		{
+			this.InitializeComponent();
+
+			this.DataContext = GetWindowViewModels();
+		}
+
+		private void HandleMetroChromeClicked(object sender, RoutedEventArgs e)
+		{
+			var viewModel = (WindowViewModel)this.WindowsListView.SelectedItem;
+			if (viewModel == null) return;
+
+			var externalWindow = new ExternalWindow(viewModel.Handle);
+			if (this._metroChrome == null)
+			{
+				this._metroChrome = new WindowChrome();
+			}
+			this._metroChrome.Attach(externalWindow);
+		}
+
+		private void HandleRefreshClicked(object sender, RoutedEventArgs e)
+		{
+			this.DataContext = GetWindowViewModels();
+		}
+
+		private static WindowViewModel[] GetWindowViewModels()
+		{
+			var currentProcess = Process.GetCurrentProcess();
+			var windows = NativeMethods.GetWindows()
+				.Where(IsValidWindow)
+				.Select(hWnd =>
+				{
+					uint pid;
+					NativeMethods.GetWindowThreadProcessId(hWnd, out pid);
+
+					var process = Process.GetProcessById((int)pid);
+					return Tuple.Create(process, hWnd);
+				})
+				.Where(tuple => tuple.Item1.Id != currentProcess.Id);
+			var viewModels = windows.Select(tuple => new WindowViewModel(tuple.Item1, tuple.Item2));
+			return viewModels.ToArray();
+		}
+
+		private static bool IsValidWindow(IntPtr hWnd)
+		{
+			// ウィンドウハンドルであるか
+			if (!User32.IsWindow(hWnd)) return false;
+
+			// 見えるか
+			if (!User32.IsWindowVisible(hWnd)) return false;
+
+			// シェル ウィンドウでないか
+			if (NativeMethods.GetShellWindow() == hWnd) return false;
+
+			// 親ウィンドウであるか
+			if (NativeMethods.GetAncestor(hWnd, 2 /* GA_ROOT */) != hWnd) return false;
+
+			// 見えないウィンドウでないか
+			if (Dwmapi.DwmGetCloaked(hWnd)) return false;
+
+			return true;
+		}
+
+		internal static class NativeMethods
+		{
+			public delegate bool EnumWindowsCallback(IntPtr hWnd, int lParam);
+
+			[DllImport("user32.dll", ExactSpelling = true, SetLastError = true)]
+			[return: MarshalAs(UnmanagedType.Bool)]
+			private static extern bool EnumWindows(EnumWindowsCallback lpEnumFunc, IntPtr lParam);
+
+			public static IntPtr[] GetWindows()
+			{
+				var windows = new Collection<IntPtr>();
+				var ret = EnumWindows((hWnd, _) =>
+				{
+					windows.Add(hWnd);
+					return true;
+				}, IntPtr.Zero);
+				if (!ret) throw new Win32Exception(Marshal.GetLastWin32Error());
+				return windows.ToArray();
+			}
+
+			[DllImport("user32.dll", SetLastError = true)]
+			public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+			[DllImport("user32.dll", ExactSpelling = true)]
+			public static extern IntPtr GetShellWindow();
+
+			[DllImport("user32.dll", ExactSpelling = true)]
+			public static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
+		}
+	}
+
+	public class WindowViewModel : ViewModel
+	{
+		public int ProcessId { get; }
+
+		public IntPtr Handle { get; }
+
+		#region Title 変更通知プロパティ
+
+		private string _Title;
+
+		public string Title
+		{
+			get { return this._Title; }
+			set
+			{
+				if (this._Title != value)
+				{
+					this._Title = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+
+		#endregion
+
+		#region Icon 変更通知プロパティ
+
+		private ImageSource _Icon;
+
+		public ImageSource Icon
+		{
+			get { return this._Icon; }
+			set
+			{
+				if (this._Icon != value)
+				{
+					this._Icon = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+
+		#endregion
+
+		public WindowViewModel(Process process, IntPtr hWnd)
+		{
+			this.ProcessId = process.Id;
+			this.Handle = hWnd;
+			this.Update();
+		}
+
+		public void Update()
+		{
+			try
+			{
+				var title = NativeMethods.GetWindowText(this.Handle);
+				if (string.IsNullOrWhiteSpace(title))
+				{
+					title = "(No title)";
+				}
+				this.Title = title;
+
+				var hIcon = User32.GetClassLong(this.Handle, ClassLongPtrIndex.GCLP_HICON);
+				this.Icon = hIcon != IntPtr.Zero
+					? Imaging.CreateBitmapSourceFromHIcon(hIcon, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions())
+					: null;
+			}
+			catch (Win32Exception) { }
+		}
+
+		private static class NativeMethods
+		{
+			[DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+			private static extern int GetWindowTextLengthW(IntPtr hWnd);
+
+			[DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+			private static extern int GetWindowTextW(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+			public static string GetWindowText(IntPtr hWnd)
+			{
+				var length = GetWindowTextLengthW(hWnd);
+				if (length == 0)
+				{
+					var err = Marshal.GetLastWin32Error();
+					if (err != 0)
+					{
+						throw new Win32Exception(err);
+					}
+					else
+					{
+						return string.Empty;
+					}
+				}
+
+				var builder = new StringBuilder(length);
+				var ret = GetWindowTextW(hWnd, builder, length + 1);
+				if (ret == 0) throw new Win32Exception(Marshal.GetLastWin32Error());
+
+				return builder.ToString();
+			}
+		}
+	}
+}

--- a/samples/MetroRadiance.Showcase/UI/MainWindow.xaml
+++ b/samples/MetroRadiance.Showcase/UI/MainWindow.xaml
@@ -192,6 +192,15 @@
 
 				<ui:ControlSamples />
 			</TabItem>
+
+			<TabItem>
+				<TabItem.Header>
+					<TextBlock Text="External Chrome"
+							   Style="{StaticResource TabHeaderTextStyleKey}" />
+				</TabItem.Header>
+
+				<ui:ExternalChromeSamples />
+			</TabItem>
 		</TabControl>
 
 		<Grid Grid.Row="2"

--- a/samples/MetroRadiance.Showcase/UI/MainWindow.xaml
+++ b/samples/MetroRadiance.Showcase/UI/MainWindow.xaml
@@ -17,6 +17,17 @@
 
 	<chrome:WindowChrome.Instance>
 		<chrome:WindowChrome x:Name="WindowChrome">
+			<chrome:WindowChrome.Left>
+				<Border Background="DarkBlue"
+						Padding="24,3"
+						VerticalAlignment="Bottom">
+					<Border.LayoutTransform>
+						<RotateTransform Angle="90" />
+					</Border.LayoutTransform>
+					<TextBlock Text="UI element on Left"
+							   Foreground="White" />
+				</Border>
+			</chrome:WindowChrome.Left>
 			<chrome:WindowChrome.Top>
 				<Border Background="DarkRed"
 						Padding="24,3"

--- a/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
+++ b/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
@@ -49,6 +49,7 @@ namespace MetroRadiance.Chrome.Primitives
 		private IntPtr _handle;
 		private bool _sourceInitialized;
 		private bool _closed;
+		private bool _firstActivated;
 		private WindowState _ownerPreviewState;
 
 		protected Dpi SystemDpi { get; private set; }
@@ -165,6 +166,8 @@ namespace MetroRadiance.Chrome.Primitives
 				owner.ContentRendered -= this.OwnerContentRenderedCallback;
 			}
 			this.Visibility = Visibility.Collapsed;
+			this._firstActivated = false;
+			this._closed = false;
 		}
 
 		private bool GetIsUpdateAvailable()
@@ -191,6 +194,7 @@ namespace MetroRadiance.Chrome.Primitives
 						if (t.IsCompleted)
 						{
 							this.Visibility = Visibility.Visible;
+							this.UpdateLocationAndSizeCore();
 						}
 						else if (t.IsFaulted)
 						{
@@ -207,6 +211,7 @@ namespace MetroRadiance.Chrome.Primitives
 				else
 				{
 					this.Visibility = Visibility.Visible;
+					this.UpdateLocationAndSizeCore();
 				}
 			}
 			else
@@ -217,7 +222,7 @@ namespace MetroRadiance.Chrome.Primitives
 
 		private void UpdateLocation()
 		{
-			if (!this.GetIsUpdateAvailable()) return;
+			if (!this.GetIsUpdateAvailable() || this._ownerPreviewState != WindowState.Normal) return;
 
 			this.CheckDpiChange();
 
@@ -231,7 +236,7 @@ namespace MetroRadiance.Chrome.Primitives
 
 		protected void UpdateSize()
 		{
-			if (!this.GetIsUpdateAvailable()) return;
+			if (!this.GetIsUpdateAvailable() || this._ownerPreviewState != WindowState.Normal) return;
 
 			if (this.CheckDpiChange())
 			{
@@ -249,7 +254,7 @@ namespace MetroRadiance.Chrome.Primitives
 
 		private void UpdateLocationAndSize()
 		{
-			if (!this.GetIsUpdateAvailable()) return;
+			if (!this.GetIsUpdateAvailable() || this._ownerPreviewState != WindowState.Normal) return;
 
 			this.CheckDpiChange();
 			this.UpdateLocationAndSizeCore();
@@ -385,7 +390,6 @@ namespace MetroRadiance.Chrome.Primitives
 		{
 			if (this._closed) return;
 			this.UpdateState();
-			this.UpdateLocation();
 			this._ownerPreviewState = this.Owner.WindowState;
 		}
 
@@ -401,12 +405,13 @@ namespace MetroRadiance.Chrome.Primitives
 
 		private void OwnerActivatedCallback(object sender, EventArgs eventArgs)
 		{
+			if (!this._firstActivated) return;
+			this._firstActivated = true;
 			this.UpdateState();
 		}
 
 		private void OwnerDeactivatedCallback(object sender, EventArgs eventArgs)
 		{
-			this.UpdateState();
 		}
 
 		private void OwnerClosedCallback(object sender, EventArgs eventArgs)

--- a/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
+++ b/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -220,7 +221,7 @@ namespace MetroRadiance.Chrome.Primitives
 
 			this.CheckDpiChange();
 
-			var ownerRect = User32.GetWindowRect(this.Owner.Handle);
+			var ownerRect = GetWindowRect(this.Owner.Handle);
 			var left = this.GetLeft(ownerRect);
 			var top = this.GetTop(ownerRect);
 			var flags = SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE | SetWindowPosFlags.SWP_NOOWNERZORDER | SetWindowPosFlags.SWP_NOSENDCHANGING;
@@ -238,7 +239,7 @@ namespace MetroRadiance.Chrome.Primitives
 				return;
 			}
 
-			var ownerRect = User32.GetWindowRect(this.Owner.Handle);
+			var ownerRect = GetWindowRect(this.Owner.Handle);
 			var width = this.GetWidth(ownerRect);
 			var height = this.GetHeight(ownerRect);
 			var flags = SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE | SetWindowPosFlags.SWP_NOOWNERZORDER | SetWindowPosFlags.SWP_NOSENDCHANGING;
@@ -256,7 +257,7 @@ namespace MetroRadiance.Chrome.Primitives
 
 		private void UpdateLocationAndSizeCore()
 		{
-			var ownerRect = User32.GetWindowRect(this.Owner.Handle);
+			var ownerRect = GetWindowRect(this.Owner.Handle);
 			var left = this.GetLeft(ownerRect);
 			var top = this.GetTop(ownerRect);
 			var width = this.GetWidth(ownerRect);
@@ -283,6 +284,18 @@ namespace MetroRadiance.Chrome.Primitives
 				}
 			}
 			return false;
+		}
+
+		private static RECT GetWindowRect(IntPtr hWnd)
+		{
+			try
+			{
+				return Dwmapi.DwmGetExtendedFrameBounds(hWnd);
+			}
+			catch (COMException)
+			{
+				return User32.GetWindowRect(hWnd);
+			}
 		}
 
 		public override void OnApplyTemplate()

--- a/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
+++ b/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
@@ -220,7 +220,7 @@ namespace MetroRadiance.Chrome.Primitives
 			}
 		}
 
-		private void UpdateLocation()
+		protected void UpdateLocation()
 		{
 			if (!this.GetIsUpdateAvailable() || this._ownerPreviewState != WindowState.Normal) return;
 
@@ -432,6 +432,13 @@ namespace MetroRadiance.Chrome.Primitives
 				return new IntPtr(3);
 			}
 
+			else if (msg == (int)WindowsMessages.WM_SETTINGCHANGE)
+			{
+				this.ChangeSettings();
+				handled = true;
+				return IntPtr.Zero;
+			}
+
 			// Note: Double scaling is avoided on .NET Framework 4.6.2 or later.
 			else if (msg == (int)WindowsMessages.WM_DPICHANGED)
 			{
@@ -446,6 +453,8 @@ namespace MetroRadiance.Chrome.Primitives
 
 			return IntPtr.Zero;
 		}
+
+		protected virtual void ChangeSettings() { }
 
 		internal void Resize(SizingMode mode)
 		{

--- a/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
+++ b/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
@@ -113,7 +113,7 @@ namespace MetroRadiance.Chrome.Primitives
 		public void Attach(IChromeOwner window)
 		{
 			Action<Color> applyAccent = color =>
-				this.Background = new SolidColorBrush(Color.FromRgb(color.R, color.G, color.B));
+				this.BorderBrush = new SolidColorBrush(Color.FromRgb(color.R, color.G, color.B));
 
 			var disposable = WindowsTheme.Accent.RegisterListener(applyAccent);
 			this.Closed += (sender, e) => disposable.Dispose();

--- a/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
+++ b/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow..cs
@@ -232,7 +232,11 @@ namespace MetroRadiance.Chrome.Primitives
 		{
 			if (!this.GetIsUpdateAvailable()) return;
 
-			this.CheckDpiChange();
+			if (this.CheckDpiChange())
+			{
+				this.UpdateLocationAndSizeCore();
+				return;
+			}
 
 			var ownerRect = User32.GetWindowRect(this.Owner.Handle);
 			var width = this.GetWidth(ownerRect);
@@ -247,7 +251,11 @@ namespace MetroRadiance.Chrome.Primitives
 			if (!this.GetIsUpdateAvailable()) return;
 
 			this.CheckDpiChange();
+			this.UpdateLocationAndSizeCore();
+		}
 
+		private void UpdateLocationAndSizeCore()
+		{
 			var ownerRect = User32.GetWindowRect(this.Owner.Handle);
 			var left = this.GetLeft(ownerRect);
 			var top = this.GetTop(ownerRect);
@@ -258,7 +266,7 @@ namespace MetroRadiance.Chrome.Primitives
 			User32.SetWindowPos(this._handle, IntPtr.Zero, left, top, width, height, flags);
 		}
 
-		private void CheckDpiChange()
+		private bool CheckDpiChange()
 		{
 			if (PerMonitorDpi.IsSupported)
 			{
@@ -270,8 +278,11 @@ namespace MetroRadiance.Chrome.Primitives
 						: new ScaleTransform((double)currentDpi.X / this.SystemDpi.X, (double)currentDpi.Y / this.SystemDpi.Y);
 					this.CurrentDpi = currentDpi;
 					this.UpdateDpiResources();
+					this.UpdateLayout();
+					return true;
 				}
 			}
+			return false;
 		}
 
 		public override void OnApplyTemplate()
@@ -403,9 +414,8 @@ namespace MetroRadiance.Chrome.Primitives
 				return new IntPtr(3);
 			}
 
-			#if NET40 || NET45 || NET451 || NET452 || NET46 || NET461
 			// Note: Double scaling is avoided on .NET Framework 4.6.2 or later.
-			if (msg == (int)WindowsMessages.WM_DPICHANGED)
+			else if (msg == (int)WindowsMessages.WM_DPICHANGED)
 			{
 			//	System.Diagnostics.Debug.WriteLine("WM_DPICHANGED: " + this.GetType().Name);
 
@@ -415,7 +425,6 @@ namespace MetroRadiance.Chrome.Primitives
 				handled = true;
 				return IntPtr.Zero;
 			}
-			#endif
 
 			return IntPtr.Zero;
 		}

--- a/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow.Left.cs
+++ b/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow.Left.cs
@@ -17,12 +17,19 @@ namespace MetroRadiance.Chrome.Primitives
 				new FrameworkPropertyMetadata(nameof(LeftChromeWindow)));
 		}
 
+		private int _topScaledBorderThickness = 0;
+		private int _bottomScaledBorderThickness = 0;
+
 		public LeftChromeWindow()
 		{
 			this.SizeToContent = SizeToContent.Width;
 		}
 
-		protected override void UpdateDpiResources() { }
+		protected override void UpdateDpiResources()
+		{
+			this._topScaledBorderThickness = this.BorderThickness.Top.DpiRoundX(this.CurrentDpi);
+			this._bottomScaledBorderThickness = this.BorderThickness.Bottom.DpiRoundX(this.CurrentDpi);
+		}
 
 		protected override int GetLeft(RECT owner)
 		{
@@ -31,7 +38,7 @@ namespace MetroRadiance.Chrome.Primitives
 
 		protected override int GetTop(RECT owner)
 		{
-			return owner.Top;
+			return owner.Top - this._topScaledBorderThickness;
 		}
 
 		protected override int GetWidth(RECT owner)
@@ -41,7 +48,7 @@ namespace MetroRadiance.Chrome.Primitives
 
 		protected override int GetHeight(RECT owner)
 		{
-			return owner.Height;
+			return owner.Height + this._topScaledBorderThickness + this._bottomScaledBorderThickness;
 		}
 
 		protected override void OwnerSizeChangedCallback(object sender, EventArgs eventArgs)

--- a/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow.Left.cs
+++ b/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow.Left.cs
@@ -48,5 +48,10 @@ namespace MetroRadiance.Chrome.Primitives
 		{
 			this.UpdateSize();
 		}
+
+		protected override void ChangeSettings()
+		{
+			this.UpdateLocation();
+		}
 	}
 }

--- a/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow.Right.cs
+++ b/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow.Right.cs
@@ -17,13 +17,20 @@ namespace MetroRadiance.Chrome.Primitives
 				new FrameworkPropertyMetadata(nameof(RightChromeWindow)));
 		}
 
+		private int _topScaledBorderThickness = 0;
+		private int _bottomScaledBorderThickness = 0;
+
 		public RightChromeWindow()
 		{
 			this.SizeToContent = SizeToContent.Width;
 		}
 
-		protected override void UpdateDpiResources() { }
-		
+		protected override void UpdateDpiResources()
+		{
+			this._topScaledBorderThickness = this.BorderThickness.Top.DpiRoundX(this.CurrentDpi);
+			this._bottomScaledBorderThickness = this.BorderThickness.Bottom.DpiRoundX(this.CurrentDpi);
+		}
+
 		protected override int GetLeft(RECT owner)
 		{
 			return owner.Right;
@@ -31,7 +38,7 @@ namespace MetroRadiance.Chrome.Primitives
 
 		protected override int GetTop(RECT owner)
 		{
-			return owner.Top;
+			return owner.Top - this._topScaledBorderThickness;
 		}
 
 		protected override int GetWidth(RECT owner)
@@ -41,7 +48,7 @@ namespace MetroRadiance.Chrome.Primitives
 
 		protected override int GetHeight(RECT owner)
 		{
-			return owner.Height;
+			return owner.Height + this._topScaledBorderThickness + this._bottomScaledBorderThickness;
 		}
 	}
 }

--- a/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow.Top.cs
+++ b/source/MetroRadiance.Chrome/Chrome/Primitives/ChromeWindow.Top.cs
@@ -55,5 +55,10 @@ namespace MetroRadiance.Chrome.Primitives
 		{
 			this.UpdateSize();
 		}
+
+		protected override void ChangeSettings()
+		{
+			this.UpdateLocation();
+		}
 	}
 }

--- a/source/MetroRadiance.Chrome/Chrome/WindowChrome.cs
+++ b/source/MetroRadiance.Chrome/Chrome/WindowChrome.cs
@@ -171,9 +171,9 @@ namespace MetroRadiance.Chrome
 			this.Detach();
 
 			this._top.Attach(window);
+			this._bottom.Attach(window);
 			this._left.Attach(window);
 			this._right.Attach(window);
-			this._bottom.Attach(window);
 
 			this.CanResize = true;
 		}

--- a/source/MetroRadiance.Chrome/Themes/Generic.GlowingEdge.Left.xaml
+++ b/source/MetroRadiance.Chrome/Themes/Generic.GlowingEdge.Left.xaml
@@ -13,9 +13,11 @@
 				<ControlTemplate TargetType="{x:Type chrome:LeftGlowingEdge}">
 					<Grid>
 						<Grid.RowDefinitions>
+							<RowDefinition Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness.Top, Mode=OneTime}" />
 							<RowDefinition Height="{StaticResource TiltedCursorMarginKey}" />
 							<RowDefinition />
 							<RowDefinition Height="{StaticResource TiltedCursorMarginKey}" />
+							<RowDefinition Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness.Bottom, Mode=OneTime}" />
 						</Grid.RowDefinitions>
 						<Grid.ColumnDefinitions>
 							<ColumnDefinition Width="{x:Static chrome:GlowingEdge.__Thickness}" />
@@ -23,9 +25,11 @@
 						</Grid.ColumnDefinitions>
 
 						<Rectangle Grid.Column="1"
+								   Grid.Row="1"
 								   Grid.RowSpan="3"
 								   Fill="{TemplateBinding BorderBrush}" />
 						<Rectangle Grid.Column="0"
+								   Grid.Row="1"
 								   Grid.RowSpan="3">
 							<Rectangle.Fill>
 								<LinearGradientBrush x:Name="PART_GradientBrush"
@@ -35,19 +39,19 @@
 						</Rectangle>
 
 						<Rectangle x:Name="PART_TopLeftThumb"
-								   Grid.Row="0"
+								   Grid.Row="1"
 								   Grid.ColumnSpan="2"
 								   IsEnabled="{TemplateBinding CanResize}"
 								   Cursor="SizeNWSE"
 								   Fill="Transparent" />
 						<Rectangle x:Name="PART_LeftThumb"
-								   Grid.Row="1"
+								   Grid.Row="2"
 								   Grid.ColumnSpan="2"
 								   IsEnabled="{TemplateBinding CanResize}"
 								   Cursor="SizeWE"
 								   Fill="Transparent" />
 						<Rectangle x:Name="PART_BottomLeftThumb"
-								   Grid.Row="2"
+								   Grid.Row="3"
 								   Grid.ColumnSpan="2"
 								   IsEnabled="{TemplateBinding CanResize}"
 								   Cursor="SizeNESW"

--- a/source/MetroRadiance.Chrome/Themes/Generic.GlowingEdge.Right.xaml
+++ b/source/MetroRadiance.Chrome/Themes/Generic.GlowingEdge.Right.xaml
@@ -13,9 +13,11 @@
 				<ControlTemplate TargetType="{x:Type chrome:RightGlowingEdge}">
 					<Grid>
 						<Grid.RowDefinitions>
+							<RowDefinition Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness.Top, Mode=OneTime}" />
 							<RowDefinition Height="{StaticResource TiltedCursorMarginKey}" />
 							<RowDefinition />
 							<RowDefinition Height="{StaticResource TiltedCursorMarginKey}" />
+							<RowDefinition Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness.Bottom, Mode=OneTime}" />
 						</Grid.RowDefinitions>
 						<Grid.ColumnDefinitions>
 							<ColumnDefinition Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness.Right, Mode=OneTime}" />
@@ -23,9 +25,11 @@
 						</Grid.ColumnDefinitions>
 
 						<Rectangle Grid.Column="0"
+								   Grid.Row="1"
 								   Grid.RowSpan="3"
 								   Fill="{TemplateBinding BorderBrush}" />
 						<Rectangle Grid.Column="1"
+								   Grid.Row="1"
 								   Grid.RowSpan="3">
 							<Rectangle.Fill>
 								<LinearGradientBrush x:Name="PART_GradientBrush"
@@ -35,19 +39,19 @@
 						</Rectangle>
 
 						<Rectangle x:Name="PART_TopRightThumb"
-								   Grid.Row="0"
+								   Grid.Row="1"
 								   Grid.ColumnSpan="2"
 								   IsEnabled="{TemplateBinding CanResize}"
 								   Cursor="SizeNESW"
 								   Fill="Transparent" />
 						<Rectangle x:Name="PART_RightThumb"
-								   Grid.Row="1"
+								   Grid.Row="2"
 								   Grid.ColumnSpan="2"
 								   IsEnabled="{TemplateBinding CanResize}"
 								   Cursor="SizeWE"
 								   Fill="Transparent" />
 						<Rectangle x:Name="PART_BottomRightThumb"
-								   Grid.Row="2"
+								   Grid.Row="3"
 								   Grid.ColumnSpan="2"
 								   IsEnabled="{TemplateBinding CanResize}"
 								   Cursor="SizeNWSE"

--- a/source/MetroRadiance.Core/Interop/Win32/Dwmapi.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/Dwmapi.cs
@@ -15,7 +15,17 @@ namespace MetroRadiance.Interop.Win32
 		public static extern void DwmGetWindowAttribute(IntPtr hWnd, DWMWINDOWATTRIBUTE dwAttribute, [Out] out RECT pvAttribute, uint cbAttribute);
 
 		[DllImport("Dwmapi.dll", EntryPoint = "DwmGetWindowAttribute", ExactSpelling = true, PreserveSig = false)]
+		public static extern void DwmGetWindowAttributeAsBoolean(IntPtr hWnd, DWMWINDOWATTRIBUTE dwAttribute, [Out] out bool pvAttribute, uint cbAttribute);
+
+		[DllImport("Dwmapi.dll", EntryPoint = "DwmGetWindowAttribute", ExactSpelling = true, PreserveSig = false)]
 		public static extern void DwmGetWindowAttributeAsRectangle(IntPtr hWnd, DWMWINDOWATTRIBUTE dwAttribute, [Out] out RECT pvAttribute, uint cbAttribute);
+
+		public static bool DwmGetCloaked(IntPtr hWnd)
+		{
+			bool cloaked;
+			DwmGetWindowAttributeAsBoolean(hWnd, DWMWINDOWATTRIBUTE.DWMWA_CLOAKED, out cloaked, (uint)Marshal.SizeOf(typeof(bool)));
+			return cloaked;
+		}
 
 		public static RECT DwmGetCaptionButtonBounds(IntPtr hWnd)
 		{

--- a/source/MetroRadiance.Core/Interop/Win32/Dwmapi.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/Dwmapi.cs
@@ -10,8 +10,25 @@ namespace MetroRadiance.Interop.Win32
 		[DllImport("Dwmapi.dll", ExactSpelling = true, PreserveSig = false)]
 		public static extern void DwmGetColorizationColor([Out] out uint pcrColorization, [Out, MarshalAs(UnmanagedType.Bool)] out bool pfOpaqueBlend);
 
+		[Obsolete("MetroRadiance.Interop.Win32.DwmGetWindowAttributeAsRectangle を使用してください")]
 		[DllImport("Dwmapi.dll", ExactSpelling = true, PreserveSig = false)]
-		public static extern void DwmGetWindowAttribute(IntPtr hWnd, DWMWINDOWATTRIBUTE dwAttribute, [Out] out RECT pvAttribute, int cbAttribute);
+		public static extern void DwmGetWindowAttribute(IntPtr hWnd, DWMWINDOWATTRIBUTE dwAttribute, [Out] out RECT pvAttribute, uint cbAttribute);
 
+		[DllImport("Dwmapi.dll", EntryPoint = "DwmGetWindowAttribute", ExactSpelling = true, PreserveSig = false)]
+		public static extern void DwmGetWindowAttributeAsRectangle(IntPtr hWnd, DWMWINDOWATTRIBUTE dwAttribute, [Out] out RECT pvAttribute, uint cbAttribute);
+
+		public static RECT DwmGetCaptionButtonBounds(IntPtr hWnd)
+		{
+			RECT rect;
+			DwmGetWindowAttributeAsRectangle(hWnd, DWMWINDOWATTRIBUTE.DWMWA_CAPTION_BUTTON_BOUNDS, out rect, (uint)Marshal.SizeOf(typeof(RECT)));
+			return rect;
+		}
+
+		public static RECT DwmGetExtendedFrameBounds(IntPtr hWnd)
+		{
+			RECT rect;
+			DwmGetWindowAttributeAsRectangle(hWnd, DWMWINDOWATTRIBUTE.DWMWA_EXTENDED_FRAME_BOUNDS, out rect, (uint)Marshal.SizeOf(typeof(RECT)));
+			return rect;
+		}
 	}
 }

--- a/source/MetroRadiance.Core/Interop/Win32/User32.cs
+++ b/source/MetroRadiance.Core/Interop/Win32/User32.cs
@@ -86,30 +86,30 @@ namespace MetroRadiance.Interop.Win32
 		[DllImport("user32.dll", EntryPoint = "SendMessageW", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
 		public static extern IntPtr SendMessage(IntPtr hWnd, WindowsMessages msg, IntPtr wParam, IntPtr lParam);
 
-		public static WindowClassStyles GetClassLong(IntPtr hwnd, ClassLongPtrIndex nIndex)
+		public static IntPtr GetClassLong(IntPtr hwnd, ClassLongPtrIndex nIndex)
 		{
 			return Environment.Is64BitProcess
-				? (WindowClassStyles)GetClassLong64(hwnd, nIndex)
-				: (WindowClassStyles)GetClassLong32(hwnd, nIndex);
+				? GetClassLong64(hwnd, nIndex)
+				: GetClassLong32(hwnd, nIndex);
 		}
 
-		[DllImport("user32.dll", EntryPoint = "GetClassLong")]
+		[DllImport("user32.dll", EntryPoint = "GetClassLongW", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
 		public static extern IntPtr GetClassLong32(IntPtr hwnd, ClassLongPtrIndex nIndex);
 
-		[DllImport("user32.dll", EntryPoint = "GetClassLongPtr")]
+		[DllImport("user32.dll", EntryPoint = "GetClassLongPtrW", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
 		public static extern IntPtr GetClassLong64(IntPtr hwnd, ClassLongPtrIndex nIndex);
 
-		public static WindowClassStyles SetClassLong(IntPtr hwnd, ClassLongPtrIndex nIndex, WindowClassStyles dwNewLong)
+		public static IntPtr SetClassLong(IntPtr hwnd, ClassLongPtrIndex nIndex, IntPtr dwNewLong)
 		{
 			return Environment.Is64BitProcess
-				? (WindowClassStyles)SetClassLong64(hwnd, nIndex, (IntPtr)dwNewLong)
-				: (WindowClassStyles)SetClassLong32(hwnd, nIndex, (IntPtr)dwNewLong);
+				? SetClassLong64(hwnd, nIndex, dwNewLong)
+				: SetClassLong32(hwnd, nIndex, dwNewLong);
 		}
 
-		[DllImport("user32.dll", EntryPoint = "SetClassLong")]
+		[DllImport("user32.dll", EntryPoint = "SetClassLongW", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
 		public static extern IntPtr SetClassLong32(IntPtr hWnd, ClassLongPtrIndex nIndex, IntPtr dwNewLong);
 
-		[DllImport("user32.dll", EntryPoint = "SetClassLongPtr")]
+		[DllImport("user32.dll", EntryPoint = "SetClassLongPtrW", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
 		public static extern IntPtr SetClassLong64(IntPtr hWnd, ClassLongPtrIndex nIndex, IntPtr dwNewLong);
 
 		[DllImport("user32.dll", EntryPoint = "GetMonitorInfoW", SetLastError = true, ExactSpelling = true)]


### PR DESCRIPTION
### Changes

- Fixed an issue that the position of `ChromeWindow` is misplaced in the following three cases.
  - The main window is initialized by different DPI from System DPI.
  - The DPI is changed during resizing with a boundary.
  - The main window returns from a minimized state.
  - The OS font size setting has been changed.
- Changed to show the contents of both left and right `ChromeWindow` from the edge of the window's border.
  No-patched　　Patched
  <img width="50" alt="metroradiance-fix-leftrightchrome-before" src="https://user-images.githubusercontent.com/901816/91638540-3c19ec00-ea4b-11ea-8460-d27b8d8adaad.png">　　　　<img width="48" alt="metroradiance-fix-leftrightchrome-after" src="https://user-images.githubusercontent.com/901816/91638542-420fcd00-ea4b-11ea-8d76-316023c839c5.png">
- Fixed an issue that `ChromeWindow` doesn't light up in case of an external window.
- Fixed an issue that `ChromeWindow`'s position isn't correct in case of external window.
- Added a GUI for glowing external windows.
  <img width="984" alt="new GUI" src="https://user-images.githubusercontent.com/901816/91211670-1c807c00-e74a-11ea-8ea1-d5a300e13842.png">

---

### 変更点

- 以下の4ケースにおいて，`ChromeWindow`の位置がずれる不具合の修正。
  - System DPI 以外の DPI で初期化された場合
  - 境界線を使ってリサイズ中に DPI が変更された場合
  - 最小化状態から復帰する場合
  - OSの文字サイズ設定が変更された場合
- 左右の `ChromeWindow` のコンテンツ表示を境界線の端から表示できるように変更しました。
  変更前　　　　変更後
  <img width="50" alt="metroradiance-fix-leftrightchrome-before" src="https://user-images.githubusercontent.com/901816/91638540-3c19ec00-ea4b-11ea-8460-d27b8d8adaad.png">　　　　<img width="48" alt="metroradiance-fix-leftrightchrome-after" src="https://user-images.githubusercontent.com/901816/91638542-420fcd00-ea4b-11ea-8d76-316023c839c5.png">
- 外部ウィンドウの場合，`ChromeWindow` が光らない問題の修正。
- 外部ウィンドウの場合，`ChromeWindow` の位置がずれる問題の修正。
- 外部ウィンドウを光らせるための GUI を追加しました。
  <img width="984" alt="new GUI" src="https://user-images.githubusercontent.com/901816/91211670-1c807c00-e74a-11ea-8ea1-d5a300e13842.png">

<sub>すみません，#44 のデバッグが不十分でした。</sub>

### 補足 (Japanese only)

手元の Visual Studio 2015 でビルドしたものだと，外部ウィンドウを光らせる機能が正常に動作しない (外部ウィンドウからのイベントが飛んでこない) みたいです。
Visual Studio 2019 に移行するための PR を準備中なのですが，そちらの .NET Framework 4.5.2 の場合は動くのですが😢
原因がよくわかっていないため，外部ウィンドウ関連のみ Visual Studio 2019 でビルドしたものでテストしています。

また，.NET Core 3.1 では C++/CLI 関連のロードに失敗するようで，正常に動作しませんでした。