### PR TITLE
Added default TextBox theme

### DIFF
--- a/samples/MetroRadiance.Showcase/UI/ControlSamples.xaml
+++ b/samples/MetroRadiance.Showcase/UI/ControlSamples.xaml
@@ -24,6 +24,8 @@
 					  Margin="4" />
 			<StackPanel Margin="12,0"
 						IsEnabled="{Binding ElementName=EnabledCheck, Path=IsChecked}">
+				<TextBox Margin="5"
+						 Text="TextBox" />
 				<metro:PromptTextBox Margin="5">
 					<metro:PromptTextBox.Text>
 						<Binding Path="Int32"

--- a/source/MetroRadiance/MetroRadiance.csproj
+++ b/source/MetroRadiance/MetroRadiance.csproj
@@ -98,6 +98,11 @@
       <Generator>MSBuild:Compile</Generator>
       <DependentUpon>Controls.xaml</DependentUpon>
     </Page>
+    <Page Include="Styles\Controls.TextBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+      <DependentUpon>Controls.xaml</DependentUpon>
+    </Page>
     <Page Include="Styles\Controls.Tooltip.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/source/MetroRadiance/Styles/Controls.PasswordBox.xaml
+++ b/source/MetroRadiance/Styles/Controls.PasswordBox.xaml
@@ -12,55 +12,60 @@
 				Value=".99" />
 		<Setter Property="Padding"
 				Value="1" />
-		<Setter Property="VerticalContentAlignment"
-				Value="Center" />
+		<Setter Property="KeyboardNavigation.TabNavigation"
+				Value="None" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Left" />
 		<Setter Property="FocusVisualStyle"
-				Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" />
+				Value="{x:Null}" />
+		<Setter Property="AllowDrop"
+				Value="True" />
+		<Setter Property="ScrollViewer.PanningMode"
+				Value="VerticalFirst" />
+		<Setter Property="Stylus.IsFlicksEnabled"
+				Value="False" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type PasswordBox}">
 					<Border Background="{TemplateBinding Background}"
 							BorderBrush="{TemplateBinding BorderBrush}"
 							BorderThickness="{TemplateBinding BorderThickness}"
-							SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-						<Grid>
-							<ScrollViewer x:Name="PART_ContentHost"
-										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-										  Margin="{TemplateBinding Padding}"
-										  Background="Transparent" />
-						</Grid>
+							SnapsToDevicePixels="True">
+						<ScrollViewer x:Name="PART_ContentHost"
+									  Margin="{TemplateBinding Padding}"
+									  Focusable="False"
+									  HorizontalScrollBarVisibility="Hidden"
+									  VerticalScrollBarVisibility="Hidden"
+									  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 					</Border>
+					<ControlTemplate.Triggers>
+						<Trigger Property="IsMouseOver"
+								 Value="True">
+							<Setter Property="Background"
+									Value="{DynamicResource ActiveBackgroundBrushKey}" />
+							<Setter Property="BorderBrush"
+									Value="{DynamicResource ActiveBorderBrushKey}" />
+						</Trigger>
+						<Trigger Property="IsKeyboardFocused"
+								 Value="True">
+							<Setter Property="Background"
+									Value="{DynamicResource ActiveBackgroundBrushKey}" />
+							<Setter Property="BorderBrush"
+									Value="{DynamicResource ActiveBorderBrushKey}" />
+						</Trigger>
+						<Trigger Property="IsEnabled"
+								 Value="False">
+							<Setter Property="Background"
+									Value="{DynamicResource InactiveBackgroundBrushKey}" />
+							<Setter Property="BorderBrush"
+									Value="{DynamicResource InactiveBorderBrushKey}" />
+							<Setter Property="Foreground"
+									Value="{DynamicResource InactiveForegroundBrushKey}" />
+						</Trigger>
+					</ControlTemplate.Triggers>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-		<Style.Triggers>
-			<Trigger Property="IsMouseOver"
-					 Value="True">
-				<Setter Property="Background"
-						Value="{DynamicResource ActiveBackgroundBrushKey}" />
-				<Setter Property="BorderBrush"
-						Value="{DynamicResource ActiveBorderBrushKey}" />
-			</Trigger>
-
-			<Trigger Property="IsKeyboardFocusWithin"
-					 Value="True">
-				<Setter Property="Background"
-						Value="{DynamicResource ActiveBackgroundBrushKey}" />
-				<Setter Property="BorderBrush"
-						Value="{DynamicResource ActiveBorderBrushKey}" />
-			</Trigger>
-
-			<Trigger Property="IsEnabled"
-					 Value="False">
-				<Setter Property="Background"
-						Value="{DynamicResource InactiveBackgroundBrushKey}" />
-				<Setter Property="BorderBrush"
-						Value="{DynamicResource InactiveBorderBrushKey}" />
-				<Setter Property="Foreground"
-						Value="{DynamicResource InactiveForegroundBrushKey}" />
-			</Trigger>
-		</Style.Triggers>
 	</Style>
 
 </ResourceDictionary>

--- a/source/MetroRadiance/Styles/Controls.TextBox.xaml
+++ b/source/MetroRadiance/Styles/Controls.TextBox.xaml
@@ -1,0 +1,74 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<Style TargetType="{x:Type TextBoxBase}">
+		<Setter Property="Background"
+				Value="{DynamicResource SemiactiveBackgroundBrushKey}" />
+		<Setter Property="BorderBrush"
+				Value="{DynamicResource SemiactiveBorderBrushKey}" />
+		<Setter Property="Foreground"
+				Value="{DynamicResource ActiveForegroundBrushKey}" />
+		<Setter Property="BorderThickness"
+				Value=".99" />
+		<Setter Property="Padding"
+				Value="1" />
+		<Setter Property="KeyboardNavigation.TabNavigation"
+				Value="None" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Left" />
+		<Setter Property="FocusVisualStyle"
+				Value="{x:Null}" />
+		<Setter Property="AllowDrop"
+				Value="True" />
+		<Setter Property="ScrollViewer.PanningMode"
+				Value="VerticalFirst" />
+		<Setter Property="Stylus.IsFlicksEnabled"
+				Value="False" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="{x:Type TextBoxBase}">
+					<Border Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							BorderThickness="{TemplateBinding BorderThickness}"
+							SnapsToDevicePixels="True">
+						<ScrollViewer x:Name="PART_ContentHost"
+									  Margin="{TemplateBinding Padding}"
+									  Focusable="False"
+									  HorizontalScrollBarVisibility="Hidden"
+									  VerticalScrollBarVisibility="Hidden"
+									  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+					</Border>
+					<ControlTemplate.Triggers>
+						<Trigger Property="IsMouseOver"
+								 Value="True">
+							<Setter Property="Background"
+									Value="{DynamicResource ActiveBackgroundBrushKey}" />
+							<Setter Property="BorderBrush"
+									Value="{DynamicResource ActiveBorderBrushKey}" />
+						</Trigger>
+						<Trigger Property="IsKeyboardFocused"
+								 Value="True">
+							<Setter Property="Background"
+									Value="{DynamicResource ActiveBackgroundBrushKey}" />
+							<Setter Property="BorderBrush"
+									Value="{DynamicResource ActiveBorderBrushKey}" />
+						</Trigger>
+						<Trigger Property="IsEnabled"
+								 Value="False">
+							<Setter Property="Background"
+									Value="{DynamicResource InactiveBackgroundBrushKey}" />
+							<Setter Property="BorderBrush"
+									Value="{DynamicResource InactiveBorderBrushKey}" />
+							<Setter Property="Foreground"
+									Value="{DynamicResource InactiveForegroundBrushKey}" />
+						</Trigger>
+					</ControlTemplate.Triggers>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style TargetType="{x:Type TextBox}"
+		   BasedOn="{StaticResource {x:Type TextBoxBase}}" />
+
+</ResourceDictionary>

--- a/source/MetroRadiance/Styles/Controls.xaml
+++ b/source/MetroRadiance/Styles/Controls.xaml
@@ -9,6 +9,7 @@
 		<ResourceDictionary Source="pack://application:,,,/MetroRadiance;component/Styles/Controls.PasswordBox.xaml" />
 		<ResourceDictionary Source="pack://application:,,,/MetroRadiance;component/Styles/Controls.RadioButton.xaml" />
 		<ResourceDictionary Source="pack://application:,,,/MetroRadiance;component/Styles/Controls.Scrollbar.xaml" />
+		<ResourceDictionary Source="pack://application:,,,/MetroRadiance;component/Styles/Controls.TextBox.xaml" />
 		<ResourceDictionary Source="pack://application:,,,/MetroRadiance;component/Styles/Controls.Tooltip.xaml" />
 	</ResourceDictionary.MergedDictionaries>
 


### PR DESCRIPTION
Add default `TextBox` theme and apply the same style to `PasswordBox`.

Fixed one of #22.

As below:

- Default:
  <img width="550" alt="add-textbox-theme-default" src="https://user-images.githubusercontent.com/901816/91694727-04748680-eba8-11ea-9d11-bba60d1d69bf.png">
- Focus:
  <img width="550" alt="add-textbox-theme-focus" src="https://user-images.githubusercontent.com/901816/91694733-08080d80-eba8-11ea-8cee-60120ad84088.png">
- Disable:
  <img width="550" alt="add-textbox-theme-disable" src="https://user-images.githubusercontent.com/901816/91694740-0b02fe00-eba8-11ea-9384-93d0024d8d8e.png">
